### PR TITLE
Make mapped <CR> trigger iabbreviations

### DIFF
--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -376,7 +376,7 @@ augroup TextBulletsMappings
 
   if g:bullets_set_mappings
     " automatic bullets
-    call s:add_local_mapping('inoremap', '<cr>', '<C-R>=<SID>insert_new_bullet()<cr>')
+    call s:add_local_mapping('inoremap', '<cr>', '<C-]><C-R>=<SID>insert_new_bullet()<cr>')
     call s:add_local_mapping('inoremap', '<C-cr>', '<cr>')
 
     call s:add_local_mapping('nnoremap', 'o', ':call <SID>insert_new_bullet()<cr>')


### PR DESCRIPTION
From `:help abbreviations`:

An abbreviation is only recognized when you type a non-keyword character.
This can also be the `<Esc>` that ends insert mode or the `<CR>` that ends a
command. The non-keyword character which ends the abbreviation is inserted
after the expanded abbreviation. **An exception to this is the character `<C-]>`,
which is used to expand an abbreviation without inserting any extra
characters.**