### PR TITLE
Escape dot for pandoc lists

### DIFF
--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -85,7 +85,7 @@ fun! s:match_roman_list_item(input_text)
 endfun
 
 fun! s:match_bullet_list_item(input_text)
-  let l:std_bullet_regex  = '\v(^\s*(-|*|#.|\\item)( \[[x ]?\])? )(.*)'
+  let l:std_bullet_regex  = '\v(^\s*(-|*|#\.|\\item)( \[[x ]?\])? )(.*)'
   let l:matches           = matchlist(a:input_text, l:std_bullet_regex)
 
   if empty(l:matches)


### PR DESCRIPTION
I noticed markdown h2 headings (`##`) were being recognized as bullets because the dot acts as a wildcard.