### PR TITLE
Add support for Org mode headers

### DIFF
--- a/doc/bullets.txt
+++ b/doc/bullets.txt
@@ -31,6 +31,7 @@ types:
 1. Numeric lists
 2) or this style of numeric lists
 \item latex item lists
+**** Org mode headers
 
 Future versions aim to support the following:
 

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -94,6 +94,11 @@ fun! s:match_bullet_list_item(input_text)
   let l:matches           = matchlist(a:input_text, l:std_bullet_regex)
 
   if empty(l:matches)
+    let l:orgmode_header_regex = '\v(^(\*+)() )(.*)'
+    let l:matches              = matchlist(a:input_text, l:orgmode_header_regex)
+  endif
+
+  if empty(l:matches)
     return {}
   endif
 


### PR DESCRIPTION
Add support for Org mode headers. These are different from bullet lists in that they start with leading asterisks rather than spaces, i.e.

`*** My subsubheader`

rather than

`  * My subsubheader`.

The `[X]` checkboxes are not allowed according to Org mode's syntax, so it warrants it's own regular expression.