### PR TITLE
Update documents

### DIFF
--- a/doc/bullets.txt
+++ b/doc/bullets.txt
@@ -211,6 +211,29 @@ o           Inserts a new bullet list item. Same as <CR> in INSERT MODE.
                                             *bullets-<leader>x*
 <leader>x   Toggles the checkbox on the current line.
 
+VISUAL MODE
+
+                                            *bullets-v_gN*
+gN          Renumbers selected bullet list items.
+
+OPERATOR-PENDING MODE
+
+                                            *bullets-ab*
+ab          "a bullet block", select a bullet block, including the bullet
+            leader.
+
+                                            *bullets-ib*
+ib          "inner bullet block", select a bullet block, excluding the bullet
+            leader.
+
+                                            *bullets-ac*
+ac          "a checkbox block", select a checkbox block, including the '[' and
+            ']'.
+
+                                            *bullets-ic*
+ic          "inner checkbox block", select a checkbox block, excluding the '['
+            and ']'.
+
 
 
 vim:tw=78:et:ft=help:norl:

--- a/doc/bullets.txt
+++ b/doc/bullets.txt
@@ -197,8 +197,8 @@ INSERT MODE
 
                                             *bullets-i_<cr>*
 <CR>        Inserts a new bullet list item based on the current line bullet
-            format. This a local mapping and will only affect the current buffer
-            if it has a supported file type (see |bullets-configuration|).
+            format. This is a local mapping and will only affect the current
+            buffer if it has a supported file type (see |bullets-configuration|).
 
                                             *bullets-i_<C-cr>*
 <C-CR>      Same as <CR>, in case you want to unmap <CR> in INSERT MODE.
@@ -206,7 +206,7 @@ INSERT MODE
 NORMAL MODE
 
                                             *bullets-o*
-<o>         Inserts a new bullet list item. Same as <CR> in INSERT MODE.
+o           Inserts a new bullet list item. Same as <CR> in INSERT MODE.
 
                                             *bullets-<leader>x*
 <leader>x   Toggles the checkbox on the current line.

--- a/doc/bullets.txt
+++ b/doc/bullets.txt
@@ -203,12 +203,6 @@ INSERT MODE
                                             *bullets-i_<C-cr>*
 <C-CR>      Same as <CR>, in case you want to unmap <CR> in INSERT MODE.
 
-                                            *bullets-i_<C-l>*
-<C-l>       Indent current bullet list item to the right by two spaces.
-
-                                            *bullets-i_<C-h>*
-<C-h>       Indent current bullet list item to the left by two spaces.
-
 NORMAL MODE
 
                                             *bullets-o*


### PR DESCRIPTION
`i_<C-l>` and `i_<C-h>` mappings are removed by https://github.com/dkarter/bullets.vim/commit/83d4609148f9cb146f4625bab29da1e2713c125e.