### PR TITLE
Match case regardless of "ignorecase" option

### DIFF
--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -74,7 +74,7 @@ fun! s:match_numeric_list_item(input_text)
 endfun
 
 fun! s:match_roman_list_item(input_text)
-  let l:rom_bullet_regex  = '\v^((\s*)([IVXLCDM]+)(\.|\))(\s*))(.*)'
+  let l:rom_bullet_regex  = '\v\C^((\s*)([IVXLCDM]+)(\.|\))(\s*))(.*)'
   let l:matches           = matchlist(a:input_text, l:rom_bullet_regex)
   if empty(l:matches)
     return {}

--- a/spec/bullets_spec.rb
+++ b/spec/bullets_spec.rb
@@ -166,6 +166,18 @@ RSpec.describe 'Bullets.vim' do
         TEXT
       end
 
+      it 'does not confuse with the "ignorecase" option' do
+        vim.command 'set ignorecase'
+        test_bullet_inserted('second line', <<-INIT, <<-EXPECTED)
+          # Hello there
+          Vi. this is the first line
+        INIT
+          # Hello there
+          Vi. this is the first line
+          second line
+        EXPECTED
+      end
+
       it 'deletes the last bullet if it is empty' do
         filename = "#{SecureRandom.hex(6)}.txt"
         write_file(filename, <<-TEXT)


### PR DESCRIPTION
When `ignorecase` is set, the regex for roman bullets are matched to mixed case strings and lowercase strings.