### PR TITLE
Support lowercase roman bullets

### DIFF
--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -74,7 +74,7 @@ fun! s:match_numeric_list_item(input_text)
 endfun
 
 fun! s:match_roman_list_item(input_text)
-  let l:rom_bullet_regex  = '\v\C^((\s*)([IVXLCDM]+)(\.|\))(\s*))(.*)'
+  let l:rom_bullet_regex  = '\v\C^((\s*)([IVXLCDM]+|[ivxlcdm]+)(\.|\))(\s*))(.*)'
   let l:matches           = matchlist(a:input_text, l:rom_bullet_regex)
   if empty(l:matches)
     return {}
@@ -194,7 +194,8 @@ endfun
 
 fun! s:next_bullet_str(bullet)
   if a:bullet.bullet_type ==# 'rom'
-    let l:next_num = s:arabic2roman(s:roman2arabic(a:bullet.bullet) + 1)
+    let l:islower = a:bullet.bullet ==# tolower(a:bullet.bullet)
+    let l:next_num = s:arabic2roman(s:roman2arabic(a:bullet.bullet) + 1, l:islower)
     return a:bullet.leading_space . l:next_num . a:bullet.closure  . ' '
   elseif a:bullet.bullet_type ==# 'num'
     let l:next_num = a:bullet.bullet + 1
@@ -362,7 +363,7 @@ function! s:roman2arabic(roman)
   return l:arabic
 endfunction
 
-function! s:arabic2roman(arabic)
+function! s:arabic2roman(arabic, islower)
   if a:arabic <= 0
     let l:arabic = -a:arabic
     let l:roman = 'n'
@@ -374,7 +375,7 @@ function! s:arabic2roman(arabic)
     let l:roman .= repeat(l:letters, l:arabic / l:numbers)
     let l:arabic = l:arabic % l:numbers
   endfor
-  return toupper(l:roman)
+  return a:islower ? tolower(l:roman) : toupper(l:roman)
 endfunction
 
 " Roman numerals ---------------------------------------------- }}}

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -74,7 +74,7 @@ fun! s:match_numeric_list_item(input_text)
 endfun
 
 fun! s:match_roman_list_item(input_text)
-  let l:rom_bullet_regex  = '\v\C^((\s*)([IVXLCDM]+|[ivxlcdm]+)(\.|\))(\s*))(.*)'
+  let l:rom_bullet_regex  = '\v\C^((\s*)([IVXLCDM]+|[ivxlcdm]+)(\.|\))(\s+))(.*)'
   let l:matches           = matchlist(a:input_text, l:rom_bullet_regex)
   if empty(l:matches)
     return {}

--- a/spec/bullets_spec.rb
+++ b/spec/bullets_spec.rb
@@ -166,6 +166,38 @@ RSpec.describe 'Bullets.vim' do
         TEXT
       end
 
+      it 'adds a new lowercase roman numeral bullet' do
+        filename = "#{SecureRandom.hex(6)}.txt"
+        write_file(filename, <<-TEXT)
+          # Hello there
+          i. this is the first bullet
+        TEXT
+
+        vim.command 'let g:bullets_pad_right = 0'
+        vim.edit filename
+        vim.type 'GA'
+        vim.feedkeys '\<cr>'
+        vim.type 'second bullet'
+        vim.feedkeys '\<cr>'
+        vim.type 'third bullet'
+        vim.feedkeys '\<cr>'
+        vim.type 'fourth bullet'
+        vim.feedkeys '\<cr>'
+        vim.type 'fifth bullet'
+        vim.write
+
+        file_contents = IO.read(filename)
+
+        expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+          # Hello there
+          i. this is the first bullet
+          ii. second bullet
+          iii. third bullet
+          iv. fourth bullet
+          v. fifth bullet\n
+        TEXT
+      end
+
       it 'does not confuse with the "ignorecase" option' do
         vim.command 'set ignorecase'
         test_bullet_inserted('second line', <<-INIT, <<-EXPECTED)

--- a/spec/bullets_spec.rb
+++ b/spec/bullets_spec.rb
@@ -210,6 +210,17 @@ RSpec.describe 'Bullets.vim' do
         EXPECTED
       end
 
+      it 'does not insert a new roman bullets without following spaces' do
+        test_bullet_inserted('second line', <<-INIT, <<-EXPECTED)
+          # Hello there
+          m.example.com is a site.
+        INIT
+          # Hello there
+          m.example.com is a site.
+          second line
+        EXPECTED
+      end
+
       it 'deletes the last bullet if it is empty' do
         filename = "#{SecureRandom.hex(6)}.txt"
         write_file(filename, <<-TEXT)


### PR DESCRIPTION
There would be use-cases like:
```
i. the first bullet
ii. the second bullet
iii. the third bullet
```

Also this forces roman bullets to be followed by spaces to prevent:
```
m.example.com is site.
mi. the second line
```
```
vi.stackexchange.com is for Vi and Vim.
vii. the second line
```