### PR TITLE
Fix Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 os: osx
 osx_image: xcode11.3
+
+branches:
+  only:
+  - master
+
 language: ruby
 cache: bundler
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,7 @@ rvm:
 
 before_install:
   - gem install bundler
-
-addons:
-  homebrew:
-    packages:
-    - macvim
+  - brew install macvim
 
 script:
   - bundle exec rspec --format documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 os: osx
 osx_image: xcode11.3
 language: ruby
-sudo: false
 cache: bundler
 rvm:
   - '2.7.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
 
 before_install:
   - gem install bundler
-  - HOMEBREW_NO_INSTALL_CLEANUP=true brew install macvim
+  - HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_AUTO_UPDATE=1 brew install macvim
 
 script:
   - bundle exec rspec --format documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,14 @@ language: ruby
 cache: bundler
 rvm:
   - '2.7.0'
+
+before_install:
+  - gem install bundler
+
 addons:
   homebrew:
     packages:
     - macvim
+
 script:
   - bundle exec rspec --format documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
 
 before_install:
   - gem install bundler
-  - brew install macvim
+  - HOMEBREW_NO_INSTALL_CLEANUP=true brew install macvim
 
 script:
   - bundle exec rspec --format documentation


### PR DESCRIPTION
Build was broken by Travis' homebrew plugin [which uses the brew bundle command and a Brewfile under the hood](https://docs.travis-ci.com/user/installing-dependencies/#using-a-brewfile).

The error I got (in case someone else is bumping into this) is:

```
rvm $brew_ruby do brew bundle --verbose --global
/usr/local/bin/brew tap homebrew/bundle
==> Tapping homebrew/bundle
Cloning into '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle'...

[... some git log stuff from the clone ...]

Tapped (102 files, 250.9KB).
Error: Unknown command: bundle
```

This PR removes usage of the add-on and installs `macvim` directly using `brew install macvim`, ~unfortunately this causes homebrew to update it's database which slows the build down, but better slow than broken~ (fixed).

Also: 
- Removes deprecated `sudo: false` from the Travis config
- Solves double builds on CI for PRs (was building the branch and PR, when only PR is really needed)
