### PR TITLE
Remove text objects for bullets

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,15 +87,11 @@ Capybara integration testing. ❤️
 - [x] check if plugin initialized and don't load if it did
 - [x] allow <C-cr> for return without creating a bullet (only possible in GuiVim
   unfortunately)
-- [x] create a text object for bullets
-- [x] create a text object for GFM-style checkboxes
 - [x] check if user is at EOL before appending auto-bullet - they may just want to
 - [x] attempt to keep the same total bullet width even as number width varies (right padding)
 - [x] detect lists that have multiline bullets (should have no empty lines between
   lines).
 - [x] add alphabetic list
-- [ ] allow user to define a global var with custom bullets
-- [ ] create a text object for bullet list indentation
 - [ ] support for intelligent alphanumeric indented bullets e.g. 1. \t a. \t 1.
 
 ---

--- a/doc/bullets.txt
+++ b/doc/bullets.txt
@@ -38,10 +38,6 @@ B) or this style of alphabetic
 It also provides support for wrapped text in a bullet, allowing you to use the
 `textwidth` feature in Vim seamlessly.
 
-Future versions aim to support the following:
-
-]] User defined bullets
-
 
 GENERAL COMMANDS                            *bullets-commands*
 
@@ -229,25 +225,6 @@ VISUAL MODE
 
                                             *bullets-v_gN*
 gN          Renumbers selected bullet list items.
-
-OPERATOR-PENDING MODE
-
-                                            *bullets-ab*
-ab          "a bullet block", select a bullet block, including the bullet
-            leader.
-
-                                            *bullets-ib*
-ib          "inner bullet block", select a bullet block, excluding the bullet
-            leader.
-
-                                            *bullets-ac*
-ac          "a checkbox block", select a checkbox block, including the '[' and
-            ']'.
-
-                                            *bullets-ic*
-ic          "inner checkbox block", select a checkbox block, excluding the '['
-            and ']'.
-
 
 
 vim:tw=78:et:ft=help:norl:

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -573,28 +573,6 @@ endfun
 command! -range=% RenumberSelection call <SID>renumber_selection()
 " --------------------------------------------------------- }}}
 
-" Bullets ------------------------------------------------- {{{
-fun! s:find_bullet_position(lnum)
-  let line_text = getline(a:lnum)
-  return matchend(line_text, '\v^\s*(\*|-)')
-endfun
-
-fun! s:select_bullet(inner)
-  let lnum = getpos('.')[1]
-  let bullet_col = s:find_bullet_position(lnum)
-
-  if bullet_col
-    " decide if we need to select with the bullet or without
-    let offset = a:inner? 2 : 0
-    call setpos('.', [0, lnum, bullet_col + offset])
-    normal! vg_
-  endif
-endfun
-
-command! SelectBulletText call <SID>select_bullet(1)
-command! SelectBullet call <SID>select_bullet(0)
-" Bullets ------------------------------------------------- }}}
-
 " Keyboard mappings --------------------------------------- {{{
 fun! s:add_local_mapping(mapping_type, mapping, action)
   let l:file_types = join(g:bullets_enabled_file_types, ',')
@@ -635,17 +613,6 @@ augroup TextBulletsMappings
 
     " Toggle checkbox
     call s:add_local_mapping('nnoremap', '<leader>x', ':ToggleCheckbox<cr>')
-
-    " Text Objects -------------------------------------------- {{{
-    " inner bullet (just the text)
-    call s:add_local_mapping('onoremap', 'ib', ':SelectBulletText<cr>')
-    " a bullet including the bullet markup
-    call s:add_local_mapping('onoremap', 'ab', ':SelectBullet<cr>')
-    " inside a checkbox
-    call s:add_local_mapping('onoremap', 'ic', ':SelectCheckboxInside<cr>')
-    " a checkbox
-    call s:add_local_mapping('onoremap', 'ac', ':SelectCheckbox<cr>')
-    " Text Objects -------------------------------------------- }}}
   end
 augroup END
 " --------------------------------------------------------- }}}


### PR DESCRIPTION
It was cool as a learning tool to understand how vim works but really
did not care to use those - so they were not maintained and updated, nor
do I think anybody else was, and they were conflicting with built-in vim
mappings. So many reasons why I'm happy to see those gone.

[Closes #45]