### PR TITLE
Add visual mode promoting/demoting, nested renumbering, and auto-renumbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ Capybara integration testing. ❤️
   lines).
 - [x] add alphabetic list
 - [x] support for intelligent alphanumeric indented bullets e.g. 1. \t a. \t 1.
+- [x] change nested outline levels in visual mode
+- [x] support renumbering of alphabetical, roman numerals, and nested lists
 - [ ] update documentation for nested bullets
 - [ ] support for nested numerical bullets, e.g., 1. -> 1.1 -> 1.1.1, 1.1.2
-- [ ] change nested outline levels in visual mode
-- [ ] support renumbering of alphabetical, roman numerals, and nested lists
 - [ ] add option to turn non-bullet lines into new bullets with `C-t`/`>>`
 
 ---

--- a/README.md
+++ b/README.md
@@ -134,17 +134,11 @@ let g:bullets_outline_levels = ['num', 'abc', 'std*']
 " 2. second parent [ <cr><C-d> ]
 ```
 
-Enable/disable automatically renumbering the current ordered bullet list when adding/changing bullets:
+Enable/disable automatically renumbering the current ordered bullet list when changing the indent level of bullets:
 
 ```vim
 let g:bullets_renumber_on_change = 1 " default = 1
-" Example 1:
-" 1. first existing bullet
-" 2. second existing bullet [ hit <cr> ]
-" 3. new bullet [ add this new bullet ]
-" 4. third existing bullet [ this got renumbered 3 -> 4 ]
-"
-" Example 2:
+" Example:
 " 1. first existing bullet
 "   a. second existing bullet [ hit <C-t> ]
 " 2. third existing bullet [ this got renumbered 3 -> 2 when bullet 2 got demoted ]
@@ -152,8 +146,7 @@ let g:bullets_renumber_on_change = 1 " default = 1
 let g:bullets_renumber_on_change = 0
 " Example:
 " 1. first existing bullet
-" 2. second existing bullet [ hit <cr> ]
-" 3. new bullet [ add this new bullet ]
+"   a. second existing bullet [ hit <C-t> ]
 " 3. third existing bullet [ no renumbering so this bullet remained `3` ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,19 +134,31 @@ let g:bullets_outline_levels = ['num', 'abc', 'std*']
 " 2. second parent [ <cr><C-d> ]
 ```
 
-Enable/disable automatically renumbering the current ordered bullet list when changing the indent level of bullets:
+Enable/disable automatically renumbering the current ordered bullet list when changing the indent level of bullets or inserting a new bullet:
 
 ```vim
 let g:bullets_renumber_on_change = 1 " default = 1
-" Example:
+" Example 1:
 " 1. first existing bullet
 "   a. second existing bullet [ hit <C-t> ]
 " 2. third existing bullet [ this got renumbered 3 -> 2 when bullet 2 got demoted ]
+"
+" Example 2:
+" 1. first existing bullet
+" 2. second existing bullet [ use <cr>/o to add a new bullet below this ]
+" 3. new bullet
+" 4. third existing bullet [ this got renumbered 3 -> 2 when bullet 2 got demoted ]
 
 let g:bullets_renumber_on_change = 0
 " Example:
 " 1. first existing bullet
 "   a. second existing bullet [ hit <C-t> ]
+" 3. third existing bullet [ no renumbering so this bullet remained `3` ]
+"
+" Example 2:
+" 1. first existing bullet
+" 2. second existing bullet [ use <cr>/o to add a new bullet below this ]
+" 3. new bullet
 " 3. third existing bullet [ no renumbering so this bullet remained `3` ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ to go to the next line, a new list item will be created.
 
 # Configuration
 
+### Filetypes
+
 You can choose which file types this plugin will work on:
 
 ```vim
@@ -44,6 +46,146 @@ let g:bullets_enabled_file_types = [
     \ 'gitcommit',
     \ 'scratch'
     \]
+```
+
+You can disable this plugin for empty buffers (no filetype):
+
+```vim
+let g:bullets_enable_in_empty_buffers = 0 " default = 1
+```
+
+Enable/disable default key mappings:
+
+```vim
+let g:bullets_set_mappings = 0 " default = 1
+```
+
+Add a leader key before default mappings:
+
+```vim
+let g:bullets_mapping_leader = '<M-b>' " default = ''
+```
+
+Enable/disable deleting the last empty bullet when hitting `<cr>` (insert mode) or `o` (normal mode):
+
+```vim
+let g:bullets_delete_last_bullet_if_empty = 0 " default = 1
+```
+
+Line spacing between bullets (1 = no blank lines, 2 = one blank line, etc.):
+
+```vim
+let g:bullets_line_spacing = 2 " default = 1
+```
+
+Don't/add extra padding between the bullet and text when bullets are multiple characters long:
+
+```vim
+let g:bullets_pad_right = 1 " default = 1
+" I. text
+" II. text
+" III. text
+" IV.  text
+" V.   text
+"     ^ extra spaces to align the text with the longest bullet
+
+let g:bullets_pad_right = 0
+" I. text
+" II. text
+" III. text
+" IV. text
+"    ^ no extra space between bullet and text
+```
+
+Maximum number of alphabetic characters to use for bullets:
+
+```vim
+let g:bullets_max_alpha_characters = 2 " default = 2
+" ...
+" y. text
+" z. text
+" aa. text
+" ab. text
+
+let g:bullets_max_alpha_characters = 1
+" ...
+" y. text
+" z. text
+" text
+```
+
+Nested outline bullet levels:
+
+```vim
+let g:bullets_outline_levels = ['ROM', 'ABC', 'num', 'abc', 'rom', 'std-', 'std*', 'std+'] " default
+" Ordered list containing the heirarchical bullet levels, starting from the outer most level.
+" Available bullet level options (cannot use the same marker more than once)
+" ROM/rom = upper/lower case Roman numerals (e.g., I, II, III, IV)
+" ABC/abc = upper/lower case alphabetic characters (e.g., A, B, C)
+" std[-/*/+] = standard bullets using a hyphen (-), asterisk (*), or plus (+) as the marker.
+" chk = checkbox (- [ ])
+
+let g:bullets_outline_levels = ['num', 'abc', 'std*']
+" Example [keys pressed to get this bullet]:
+" 1. first parent
+"   a. child bullet [ <cr><C-t> ]
+"     - unordered bullet [ <cr><C-t> ]
+"   b. second child bullet [ <cr><C-d> ]
+" 2. second parent [ <cr><C-d> ]
+```
+
+Enable/disable automatically renumbering the current ordered bullet list when adding/changing bullets:
+
+```vim
+let g:bullets_renumber_on_change = 1 " default = 1
+" Example 1:
+" 1. first existing bullet
+" 2. second existing bullet [ hit <cr> ]
+" 3. new bullet [ add this new bullet ]
+" 4. third existing bullet [ this got renumbered 3 -> 4 ]
+"
+" Example 2:
+" 1. first existing bullet
+"   a. second existing bullet [ hit <C-t> ]
+" 2. third existing bullet [ this got renumbered 3 -> 2 when bullet 2 got demoted ]
+
+let g:bullets_renumber_on_change = 0
+" Example:
+" 1. first existing bullet
+" 2. second existing bullet [ hit <cr> ]
+" 3. new bullet [ add this new bullet ]
+" 3. third existing bullet [ no renumbering so this bullet remained `3` ]
+```
+
+# Mappings
+
+* Insert new bullet in INSERT mode: `<cr>` (Return key)
+* Same as <cr> in case you want to unmap <cr> in INSERT mode (compatibility depends on your terminal emulator): `<C-cr>`
+* Insert new bullet in NORMAL mode: `o`
+* Renumber current visual selection: `gN`
+* Renumber entire bullet list containing the cursor in NORMAL mode: gN
+* Toggle a checkbox in NORMAL mode: `<leader>x`
+* Demote a bullet (indent it, decrease bullet level, and make it a child of the previous bullet):
+  + NORMAL mode: `>>`
+  + INSERT mode: `<C-t>`
+  + VISUAL mode: `>`
+* Promote a bullet (unindent it and increase the bullet level):
+  + NORMAL mode: `<<`
+  + INSERT mode: `<C-d>`
+  + VISUAL mode: `>`
+
+Disable default mappings:
+
+```vim
+let g:bullets_set_mappings = 0
+```
+
+Add a leader key before default mappings:
+
+```vim
+let g:bullets_mapping_leader = '<M-b>' 
+" Set <M-b> to the leader before all default mappings:
+" Example: renumbering becomes `<M-b>gN` instead of just `gN`
 ```
 
 Just add above to your .vimrc
@@ -95,9 +237,9 @@ Capybara integration testing. ❤️
 - [x] support for intelligent alphanumeric indented bullets e.g. 1. \t a. \t 1.
 - [x] change nested outline levels in visual mode
 - [x] support renumbering of alphabetical, roman numerals, and nested lists
-- [ ] update documentation for nested bullets
+- [x] update documentation for nested bullets
 - [ ] support for nested numerical bullets, e.g., 1. -> 1.1 -> 1.1.1, 1.1.2
-- [ ] add option to turn non-bullet lines into new bullets with `C-t`/`>>`
+- [ ] add option to turn non-bullet lines into new bullets with `<C-t>`/`>>`/`>`
 
 ---
 

--- a/doc/bullets.txt
+++ b/doc/bullets.txt
@@ -27,13 +27,19 @@ types:
 
 - Hyphenated lists
 * Star (or bullet) lists
++ Plus (also bullet) lists
 - [ ] GFM markdown checkbox lists
 1. Numeric lists
 2) or this style of numeric lists
 a. alphabetic lists
 B) or this style of alphabetic
+i. Roman numeral lists
+II. or capitalized Roman numeral lists
 \item latex item lists
 **** Org mode headers
+
+It supports nested (heirarchical) ordered lists/outlines using different types
+of bullet markers for each level.
 
 It also provides support for wrapped text in a bullet, allowing you to use the
 `textwidth` feature in Vim seamlessly.
@@ -71,6 +77,30 @@ GENERAL COMMANDS                            *bullets-commands*
 :RenumberSelection     Renumbers all the arabic/numeric bullets lines in the
                        visual selection. Right padding is initalized to the
                        first found bullet.
+
+                                            *bullets-:RenumberList*
+:RenumberList          Renumbers all of the bullet lines in the current list.
+                       A blank line before/after the first/last bullet denotes
+                       the end of the list.
+
+                                            *bullets-:BulletDemote*
+:BulletDemote          Demotes the current bullet by indenting it and changing
+                       its bullet type to the next level defined in 
+                       g:bullets_outline_levels. Mapped to <C-t> in INSERT
+                       mode and `>>` in NORMAL mode.
+
+                                            *bullets-:BulletPromote*
+:BulletPromote         Promotes the current bullet by unindenting it and 
+                       changing its bullet type to the next level defined in 
+                       g:bullets_outline_levels. Mapped to <C-d> in INSERT
+                       mode and `<<` in NORMAL mode by default.
+
+                                            *bullets-:BulletDemoteVisual*
+:BulletDemoteVisual    Demotes the currently selected bullet(s) in VISUAL
+                       mode. Mapped to `>` in VISUAL mode by default.
+                                            *bullets-:BulletPromoteVisual*
+:BulletPromoteVisual   Promotes the currently selected bullet(s) in VISUAL
+                       mode. Mapped to `>` in VISUAL mode by default.
 
 CONFIGURATION                               *bullets-configuration*
 
@@ -161,6 +191,38 @@ that using auto commands.
 When changed to `0` this will disable alphabetic bullets altogether.
 
 
+Nested Outline Bullet Levels
+----------------------------
+You can create heirarchically nested outlines using indentation and different
+bullet types for each level of indentation. Define the type of bullet used for
+each level using the following ordered list:
+
+   `let g:bullets_outline_levels = ['ROM', 'ABC', 'num', 'abc', 'rom', 'std-',`
+  `   \ 'std*', 'std+']`
+
+Demoting a bullet ([I]<C-t>, [N]`>>`, [V]`>`) will increase its indentation and use the
+next bullet level defined in this list. Similarly, promoting the bullet
+([I]<C-d>, [N]`<<`, [V]`<`) will decrease the bullet
+indentation and use the previous bullet level. Promoting a top-level bullet
+will remove the bullet and demoting a bottom-level bullet will indent, but not
+change the bullet marker.
+
+
+Renumber Bullets on Change
+--------------------------
+By default, inserting a new bullet or promoting/demoting an existing bullet in
+the middle of a list will cause all of the list items, including nested
+bullets, to be renumbered. You can disable renumbering using the following:
+
+  `let g:bullets_renumber_on_change = 0`
+
+The current list is defined by blank lines surrounding the first/last bullet
+items, taking into consideration the setting in g:bullets_line_spacing.
+
+You can always manually renumber the current list or visual selection using
+`gN` in NORMAL or VISUAL mode.
+
+
 INSERTING BULLETS                           *bullets-insert-new-bullet*
 
 When a supported file type is opened (see |bullets-configuration|) you can start
@@ -183,8 +245,6 @@ Vim comes built in with support for indenting and de-indenting in INSERT mode.
 
 To indent the current bullet to the right: from insert mode press <CTRL-t>.
 To indent the current bullet to the left: from insert mode press <CTRL-d>.
-
-Note: For <CTRL-d> to work properly you have to be at the end of the line.
 
 For more information `:h i_CTRL-T` and `:h i_CTRL-D`
 
@@ -213,18 +273,48 @@ INSERT MODE
                                             *bullets-i_<C-cr>*
 <C-CR>      Same as <CR>, in case you want to unmap <CR> in INSERT MODE.
 
+                                            *bullets-i_<C-d>*
+<C-D>       Promotes the current bullet item by unindenting the line and
+            changing the bullet to the previous type defined in
+            g:bullets_outline_levels.
+
+                                            *bullets-i_<C-t>*
+<C-T>       Demotes the current bullet item by indenting the line and changing
+            the bullet to the next type defined in g:bullets_outline_levels.
+
 NORMAL MODE
 
                                             *bullets-o*
 o           Inserts a new bullet list item. Same as <CR> in INSERT MODE.
 
+                                            *bullets-gN*
+gN          Renumbers entire list containing the current cursor position.
+
                                             *bullets-<leader>x*
 <leader>x   Toggles the checkbox on the current line.
+
+                                            *bullets->>*
+>>          Promotes the current bullet item by unindenting the line and
+            changing the bullet to the next type defined in
+            g:bullets_outline_levels.
+
+                                            *bullets-<<*
+<<          Demotes the current bullet item by indenting the line and changing
+            the bullet to the previous type defined in g:bullets_outline_levels.
 
 VISUAL MODE
 
                                             *bullets-v_gN*
 gN          Renumbers selected bullet list items.
 
+                                            *bullets-v_>*
+>           Promotes the currently selected bullet item(s) by unindenting the
+            lines and changing the bullets to the next type defined in
+            g:bullets_outline_levels.
+
+                                            *bullets-v_<*
+<           Demotes the currently selected bullet item(s) by indenting the
+            lines and changing the bullets to the previous type defined in
+            g:bullets_outline_levels.
 
 vim:tw=78:et:ft=help:norl:

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -10,9 +10,9 @@ set cpoptions&vim
 " -------------------------------------------------------  }}}
 
 " Prevent execution if already loaded ------------------   {{{
-" if exists('g:loaded_bullets_vim')
-"   finish
-" endif
+if exists('g:loaded_bullets_vim')
+  finish
+endif
 let g:loaded_bullets_vim = 1
 " Prevent execution if already loaded ------------------   }}}
 

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -421,9 +421,6 @@ fun! s:insert_new_bullet()
       call append(l:curr_line_num, l:next_bullet_list)
       " got to next line after the new bullet
       let l:col = strlen(getline(l:next_line_num)) + 1
-      if g:bullets_renumber_on_change
-        call s:renumber_whole_list()
-      endif
       call setpos('.', [0, l:next_line_num, l:col])
       let l:send_return = 0
     endif

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -1,5 +1,5 @@
 " Vim plugin for automated bulleted lists
-" Last Change: March 12, 2020
+" Last Change: March 13, 2020
 " Maintainer: Dorian Karter
 " License: MIT
 " FileTypes: markdown, text, gitcommit

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -421,6 +421,9 @@ fun! s:insert_new_bullet()
       call append(l:curr_line_num, l:next_bullet_list)
       " got to next line after the new bullet
       let l:col = strlen(getline(l:next_line_num)) + 1
+      if g:bullets_renumber_on_change
+        call s:renumber_whole_list()
+      endif
       call setpos('.', [0, l:next_line_num, l:col])
       let l:send_return = 0
     endif

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -243,7 +243,7 @@ fun! s:closest_bullet_types(from_line_num, max_indent)
   " Support for wrapped text bullets, even if the wrapped line is not indented
   " It considers a blank line as the end of a bullet
   " DEMO: https://raw.githubusercontent.com/dkarter/bullets.vim/master/img/wrapped-bullets.gif
-  while l:lnum > 1 && (l:curr_indent != 0 || l:bullet_kinds != [] || !(l:ltxt =~ '\v^(\s+$|$)'))
+  while l:lnum > 1 && (l:curr_indent != 0 || l:bullet_kinds != [] || !(l:ltxt =~# '\v^(\s+$|$)'))
         \ && (a:max_indent < l:curr_indent || l:bullet_kinds == [])
     if l:bullet_kinds != []
       let l:lnum = l:lnum - g:bullets_line_spacing
@@ -511,7 +511,7 @@ function! s:roman2arabic(roman)
       let l:sign = -l:sign
     endif
     for [l:numbers, l:letters] in s:a2r
-      if l:roman =~ '^' . l:letters
+      if l:roman =~# '^' . l:letters
         let l:arabic += l:sign * l:numbers
         let l:roman = strpart(l:roman,strlen(l:letters)-1)
         break
@@ -654,7 +654,7 @@ fun! s:renumber_whole_list(...)
       " Reset the starting visual selection
       call setpos("'<", [0, a:1[0], a:1[1], 0])
       call setpos("'>", [0, a:2[0], a:2[1], 0])
-      execute "normal! gv"
+      execute 'normal! gv'
     endif
   endif
 endfun
@@ -675,13 +675,13 @@ fun! s:change_bullet_level(direction)
       if g:bullets_renumber_on_change
         call s:renumber_whole_list()
       endif
-      execute "normal! $"
+      execute 'normal! $'
       return
     else
-      execute "normal! <<$"
+      execute 'normal! <<$'
     endif
   else
-    execute "normal! >>$"
+    execute 'normal! >>$'
   endif
 
   if l:curr_line == []
@@ -779,7 +779,7 @@ fun! s:change_bullet_level(direction)
   if g:bullets_renumber_on_change
     call s:renumber_whole_list()
   endif
-  execute "normal! $"
+  execute 'normal! $'
   return
 endfun
 

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -1,5 +1,5 @@
 " Vim plugin for automated bulleted lists
-" Last Change: March 2, 2020
+" Last Change: March 12, 2020
 " Maintainer: Dorian Karter
 " License: MIT
 " FileTypes: markdown, text, gitcommit
@@ -60,6 +60,10 @@ if !exists('g:bullets_outline_levels')
   " Capitalization matters: all caps will make the symbol caps, lower = lower
   " Standard bullets should include the marker symbol after 'std'
   let g:bullets_outline_levels = ['ROM', 'ABC', 'num', 'abc', 'rom', 'std-', 'std*', 'std+']
+endif
+
+if !exists('g:bullets_renumber_on_change')
+  let g:bullets_renumber_on_change = 1
 endif
 
 " ------------------------------------------------------   }}}
@@ -236,9 +240,10 @@ fun! s:closest_bullet_types(from_line_num, max_indent)
   let l:curr_indent = indent(l:lnum)
   let l:bullet_kinds = s:parse_bullet(l:lnum, l:ltxt)
 
-  " Support for wrapped text bullets
+  " Support for wrapped text bullets, even if the wrapped line is not indented
+  " It considers a blank line as the end of a bullet
   " DEMO: https://raw.githubusercontent.com/dkarter/bullets.vim/master/img/wrapped-bullets.gif
-  while l:lnum > 1 && (l:curr_indent != 0 || l:bullet_kinds != [])
+  while l:lnum > 1 && (l:curr_indent != 0 || l:bullet_kinds != [] || !(l:ltxt =~ '\v^(\s+$|$)'))
         \ && (a:max_indent < l:curr_indent || l:bullet_kinds == [])
     if l:bullet_kinds != []
       let l:lnum = l:lnum - g:bullets_line_spacing
@@ -564,67 +569,98 @@ endfun
 fun! s:renumber_selection()
   let l:selection_lines = s:get_visual_selection_lines()
   let l:prev_indent = -1
-  let l:level = 0
-  let l:indices = {}
-  let l:pad_len = {}
-  let l:types = {}
-  let l:islower = {}
+  let l:levels = {} " stores all the info about the current outline/list
 
   for l:line in l:selection_lines
     let l:indent = indent(l:line.nr)
     let l:bullet = s:closest_bullet_types(l:line.nr, l:indent)
     let l:bullet = s:resolve_bullet_type(l:bullet)
 
-    if !empty(l:bullet)
-      let l:level = l:indent
-      if l:indent > l:prev_indent
-        let l:indices[l:level] = 1
+    if !empty(l:bullet) && l:bullet.starting_at_line_num == l:line.nr
+      " skip wrapped lines and lines that aren't bullets
+      if l:indent > l:prev_indent || !has_key(l:levels, l:indent)
+        if !has_key(l:levels, l:indent)
+          let l:levels[l:indent] = {'index': 1}
+        endif
 
         " use the first bullet at this level to define the bullet type for
-        " subsequent bullets. Needed to normalize bullet types when there are
-        " multiple types of bullets at the same indent level.
-        let l:islower[l:level] = l:bullet.bullet ==# tolower(l:bullet.bullet)
-        let l:types[l:level] = l:bullet.bullet_type
+        " subsequent bullets at the same level. Needed to normalize bullet
+        " types when there are multiple types of bullets at the same level.
+        let l:levels[l:indent].islower = l:bullet.bullet ==# tolower(l:bullet.bullet)
+        let l:levels[l:indent].type = l:bullet.bullet_type
+        let l:levels[l:indent].bullet = l:bullet.bullet " for standard bullets
+        let l:levels[l:indent].closure = l:bullet.closure " normalize closures
 
         " use the first bullet as the first padding length, and store it for
         " each indent level
         " 10. firstline  -> 1.  firstline
         " 1.  secondline -> 2.  secondline
-        let l:pad_len[l:level] = l:bullet.bullet_length
+        let l:levels[l:indent].pad_len = l:bullet.bullet_length
       else
-        let l:indices[l:level] += 1
+        let l:levels[l:indent].index += 1
+
+        if l:indent < l:prev_indent
+          " Reset the numbering on all all child items. Needed to avoid continuing
+          " the numbering from earlier portions of the list with the same bullet
+          " type in some edge cases.
+          for l:key in keys(l:levels)
+            if l:key > l:indent
+              call remove(l:levels, l:key)
+            endif
+          endfor
+        endif
       endif
 
       let l:prev_indent = l:indent
 
-      if l:types[l:level] ==? 'rom'
-        let l:bullet_num = s:arabic2roman(l:indices[l:level], l:islower[l:level])
-      elseif l:types[l:level] ==? 'abc'
-        let l:bullet_num = s:dec2abc(l:indices[l:level], l:islower[l:level])
-      elseif l:types[l:level] ==# 'num'
-        let l:bullet_num = l:indices[l:level]
+      if l:levels[l:indent].type ==? 'rom'
+        let l:bullet_num = s:arabic2roman(l:levels[l:indent].index, l:levels[l:indent].islower)
+      elseif l:levels[l:indent].type ==? 'abc'
+        let l:bullet_num = s:dec2abc(l:levels[l:indent].index, l:levels[l:indent].islower)
+      elseif l:levels[l:indent].type ==# 'num'
+        let l:bullet_num = l:levels[l:indent].index
       else
         " standard or checkbox
-        let l:bullet_num = l:bullet.bullet
+        let l:bullet_num = l:levels[l:indent].bullet
       endif
 
       let l:new_bullet =
             \ l:bullet.leading_space
             \ . l:bullet_num
-            \ . l:bullet.closure
-            \ . (l:pad_len[l:level] == 0 ? l:bullet.trailing_space : ' ')
-      let l:new_bullet = s:pad_to_length(l:new_bullet, l:pad_len[l:level])
-      let l:pad_len[l:level] = len(l:new_bullet)
+            \ . l:levels[l:indent].closure
+            \ . (l:levels[l:indent].pad_len == 0 ? l:bullet.trailing_space : ' ')
+      let l:new_bullet = s:pad_to_length(l:new_bullet, l:levels[l:indent].pad_len)
+      let l:levels[l:indent].pad_len = len(l:new_bullet)
       let l:renumbered_line = l:new_bullet . l:bullet.text_after_bullet
       call setline(l:line.nr, l:renumbered_line)
-    else
-      call setline(l:line.nr, l:line.text)
     endif
   endfor
 endfun
 
+fun! s:renumber_whole_list(...)
+  " Renumbers the whole list containing the cursor.
+  " Does not renumber across blank lines.
+  " Takes 2 optional arguments containing starting and ending cursor positions
+  " so that we can reset the existing visual selection after renumbering.
+  let l:first_line = s:first_bullet_line()
+  let l:last_line = s:last_bullet_line()
+  if l:first_line > 0 && l:last_line > 0
+    " Create a visual selection around the current list so that we can call
+    " s:renumber_selection() to do the renumbering.
+    call setpos("'<", [0, l:first_line, 1, 0])
+    call setpos("'>", [0, l:last_line, 1, 0])
+    call s:renumber_selection()
+    if a:0 == 2
+      " Reset the starting visual selection
+      call setpos("'<", [0, a:1[0], a:1[1], 0])
+      call setpos("'>", [0, a:2[0], a:2[1], 0])
+      execute "normal! gv"
+    endif
+  endif
+endfun
 
 command! -range=% RenumberSelection call <SID>renumber_selection()
+command! RenumberList call <SID>renumber_whole_list()
 " --------------------------------------------------------- }}}
 
 " Changing outline level ---------------------------------- {{{
@@ -636,22 +672,26 @@ fun! s:change_bullet_level(direction)
     if l:curr_line != [] && indent(l:lnum) == 0
       " Promoting a bullet at the highest level will delete the bullet
       call setline(l:lnum, l:curr_line[0].text_after_bullet)
+      if g:bullets_renumber_on_change
+        call s:renumber_whole_list()
+      endif
+      execute "normal! $"
       return
     else
-      execute "normal! <<"
+      execute "normal! <<$"
     endif
   else
-    execute "normal! >>"
+    execute "normal! >>$"
+  endif
+
+  if l:curr_line == []
+    " If the current line is not a bullet then don't do anything else.
+    return
   endif
 
   let l:curr_indent = indent(l:lnum)
   let l:curr_bullet= s:closest_bullet_types(l:lnum, l:curr_indent)
   let l:curr_bullet = s:resolve_bullet_type(l:curr_bullet)
-
-  if l:curr_bullet == {}
-    " Only change the bullet level if it's currently a bullet.
-    return
-  endif
 
   let l:curr_line = l:curr_bullet.starting_at_line_num
   let l:closest_bullet = s:closest_bullet_types(l:curr_line - g:bullets_line_spacing, l:curr_indent)
@@ -663,9 +703,10 @@ fun! s:change_bullet_level(direction)
   endif
 
   let l:islower = l:closest_bullet.bullet ==# tolower(l:closest_bullet.bullet)
+  let l:closest_indent = indent(l:closest_bullet.starting_at_line_num)
+
   let l:closest_type = l:islower ? l:closest_bullet.bullet_type :
         \ toupper(l:closest_bullet.bullet_type)
-
   if l:closest_bullet.bullet_type ==# 'std'
     " Append the bullet marker to the type, e.g., 'std*'
 
@@ -673,16 +714,12 @@ fun! s:change_bullet_level(direction)
   endif
 
   let l:closest_index = index(g:bullets_outline_levels, l:closest_type)
-
   if l:closest_index == -1
     " We are in a list using markers that aren't specified in
     " g:bullets_outline_levels so we shouldn't try to change the current
     " bullet.
     return
   endif
-
-  let l:closest_indent = indent(l:closest_bullet.starting_at_line_num)
-
   if (l:curr_indent == l:closest_indent)
     " The closest bullet is a sibling so the current bullet should
     " increment to the next bullet marker.
@@ -691,19 +728,24 @@ fun! s:change_bullet_level(direction)
     let l:next_bullet_str = s:pad_to_length(l:next_bullet, l:closest_bullet.bullet_length)
           \ . l:curr_bullet.text_after_bullet
 
+  elseif l:closest_index + 1 >= len(g:bullets_outline_levels)
+        \ && l:curr_indent > l:closest_indent
+    " The closest bullet is a parent and its type is the last one defined in
+    " g:bullets_outline_levels so keep the existing bullet.
+    " TODO: Might make an option for whether the bullet should stay or be
+    " deleted when demoting past the end of the defined bullet types.
+    return
   elseif l:closest_index + 1 < len(g:bullets_outline_levels) || l:curr_indent < l:closest_indent
     " The current bullet is a child of the closest bullet so figure out
     " what bullet type it should have and set its marker to the first
     " character of that type.
 
-    let l:next_index = l:closest_index + 1
-    let l:next_type = g:bullets_outline_levels[l:next_index]
+    let l:next_type = g:bullets_outline_levels[l:closest_index + 1]
     let l:next_islower = l:next_type ==# tolower(l:next_type)
     let l:trailing_space = ' '
-
     let l:curr_bullet.closure = l:closest_bullet.closure
 
-    " set the bullet marker to the first character of that type
+    " set the bullet marker to the first character of the new type
     if l:next_type ==? 'rom'
       let l:next_num = s:arabic2roman(1, l:next_islower)
     elseif l:next_type ==? 'abc'
@@ -711,7 +753,8 @@ fun! s:change_bullet_level(direction)
     elseif l:next_type ==# 'num'
       let l:next_num = '1'
     else
-      " standard bullet; l:next_type contains the bullet symbol to use
+      " standard bullet; the last character of l:next_type contains the bullet
+      " symbol to use
       let l:next_num = strpart(l:next_type, len(l:next_type) - 1)
       let l:curr_bullet.closure = ''
     endif
@@ -732,13 +775,36 @@ fun! s:change_bullet_level(direction)
 
   " Apply the new bullet
   call setline(l:lnum, l:next_bullet_str)
-  execute 'normal! $'
 
+  if g:bullets_renumber_on_change
+    call s:renumber_whole_list()
+  endif
+  execute "normal! $"
   return
+endfun
+
+fun! s:visual_change_bullet_level(direction)
+  " Changes the bullet level for each of the selected lines
+  let l:start = getpos("'<")[1:2]
+  let l:end = getpos("'>")[1:2]
+  let l:selected_lines = range(l:start[0], l:end[0])
+  for l:lnum in l:selected_lines
+    " Iterate the cursor position over each line and then call
+    " s:change_bullet_level for that cursor position.
+    call setpos('.', [0, l:lnum, 1, 0])
+    call s:change_bullet_level(a:direction)
+  endfor
+  if g:bullets_renumber_on_change
+    " Pass the current visual selection so that it gets reset after
+    " renumbering the list.
+    call s:renumber_whole_list(l:start, l:end)
+  endif
 endfun
 
 command! BulletDemote call <SID>change_bullet_level(-1)
 command! BulletPromote call <SID>change_bullet_level(1)
+command! -range=% BulletDemoteVisual call <SID>visual_change_bullet_level(-1)
+command! -range=% BulletPromoteVisual call <SID>visual_change_bullet_level(1)
 
 " --------------------------------------------------------- }}}
 
@@ -779,6 +845,7 @@ augroup TextBulletsMappings
 
     " Renumber bullet list
     call s:add_local_mapping('vnoremap', 'gN', ':RenumberSelection<cr>')
+    call s:add_local_mapping('nnoremap', 'gN', ':RenumberList<cr>')
 
     " Toggle checkbox
     call s:add_local_mapping('nnoremap', '<leader>x', ':ToggleCheckbox<cr>')
@@ -788,7 +855,8 @@ augroup TextBulletsMappings
     call s:add_local_mapping('nnoremap', '>>', ':BulletDemote<cr>')
     call s:add_local_mapping('inoremap', '<C-d>', '<C-o>:BulletPromote<cr>')
     call s:add_local_mapping('nnoremap', '<<', ':BulletPromote<cr>')
-
+    call s:add_local_mapping('vnoremap', '>', ':BulletDemoteVisual<cr>')
+    call s:add_local_mapping('vnoremap', '<', ':BulletPromoteVisual<cr>')
   end
 augroup END
 " --------------------------------------------------------- }}}
@@ -851,6 +919,51 @@ endfun
 
 fun! s:has_item(list, fn)
   return !empty(s:find(a:list, a:fn))
+endfun
+
+fun! s:first_bullet_line()
+  " returns the line number of the first bullet in the list containing the
+  " cursor, up to the first blank line
+  " returns -1 if the cursor is not in a list
+  let l:lnum = line('.')
+  let l:first_line = -1
+  let l:curr_indent = indent(l:lnum)
+  let l:bullet_kinds = s:closest_bullet_types(l:lnum, l:curr_indent)
+
+  while l:lnum >= 1 && (l:curr_indent != 0 || l:bullet_kinds != [])
+    if l:bullet_kinds != []
+      let l:first_line = l:lnum
+      let l:lnum = l:lnum - g:bullets_line_spacing
+    else
+      let l:lnum = l:lnum - 1
+    endif
+    let l:bullet_kinds = s:closest_bullet_types(l:lnum, l:curr_indent)
+    let l:curr_indent = indent(l:lnum)
+  endwhile
+  return l:first_line
+endfun
+
+fun! s:last_bullet_line()
+  " returns the line number of the last bullet in the list containing the
+  " cursor, down to the first blank line
+  " returns -1 if the cursor is not in a list
+  let l:lnum = line('.')
+  let l:buf_end = line('$')
+  let l:last_line = -1
+  let l:curr_indent = indent(l:lnum)
+  let l:bullet_kinds = s:closest_bullet_types(l:lnum, l:curr_indent)
+
+  while l:lnum <= l:buf_end && (l:curr_indent != 0 || l:bullet_kinds != [])
+    if l:bullet_kinds != []
+      let l:last_line = l:lnum
+      let l:lnum = l:lnum + g:bullets_line_spacing
+    else
+      let l:lnum = l:lnum + 1
+    endif
+    let l:bullet_kinds = s:closest_bullet_types(l:lnum, l:curr_indent)
+    let l:curr_indent = indent(l:lnum)
+  endwhile
+  return l:last_line
 endfun
 " ------------------------------------------------------- }}}
 

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -605,11 +605,12 @@ fun! s:change_bullet_level(direction)
     if l:curr_line != [] && indent(l:lnum) == 0
       " Promoting a bullet at the highest level will delete the bullet
       call setline(l:lnum, l:curr_line[0].text_after_bullet)
+      return
     else
-      execute "normal! a\<C-d>"
+      execute "normal! <<"
     endif
   else
-    execute "normal! a\<C-t>"
+    execute "normal! >>"
   endif
 
   let l:curr_indent = indent(l:lnum)
@@ -699,16 +700,8 @@ fun! s:change_bullet_level(direction)
   endif
 
   " Apply the new bullet
-  if l:next_bullet_str !=# ''
-    call setline(l:lnum, l:next_bullet_str)
-    execute 'normal! $'
-
-  elseif g:bullets_delete_last_bullet_if_empty
-    let l:orig_line = s:parse_bullet(l:lnum, getline(l:lnum))
-    if l:orig_line != []
-      call setline(l:lnum, l:orig_line[0].leading_space . l:orig_line[0].text_after_bullet)
-    endif
-  endif
+  call setline(l:lnum, l:next_bullet_str)
+  execute 'normal! $'
 
   return
 endfun
@@ -721,8 +714,8 @@ fun! s:bullet_promote()
   call s:change_bullet_level(1)
 endfun
 
-command! BulletDemote call <SID>bullet_demote()
-command! BulletPromote call <SID>bullet_promote()
+command! BulletDemote call <SID>change_bullet_level(-1)
+command! BulletPromote call <SID>change_bullet_level(1)
 
 
 " --------------------------------------------------------- }}}
@@ -769,10 +762,10 @@ augroup TextBulletsMappings
     call s:add_local_mapping('nnoremap', '<leader>x', ':ToggleCheckbox<cr>')
 
     " Promote and Demote outline level
-    call s:add_local_mapping('inoremap', '<C-t>', '<C-o>:call <SID>bullet_demote()<cr>')
-    call s:add_local_mapping('nnoremap', '>>', ':call <SID>bullet_demote()<cr>')
-    call s:add_local_mapping('inoremap', '<C-d>', '<C-o>:call <SID>bullet_promote()<cr>')
-    call s:add_local_mapping('nnoremap', '<<', ':call <SID>bullet_promote()<cr>')
+    call s:add_local_mapping('inoremap', '<C-t>', '<C-o>:BulletDemote<cr>')
+    call s:add_local_mapping('nnoremap', '>>', ':BulletDemote<cr>')
+    call s:add_local_mapping('inoremap', '<C-d>', '<C-o>:BulletPromote<cr>')
+    call s:add_local_mapping('nnoremap', '<<', ':BulletPromote<cr>')
 
   end
 augroup END

--- a/spec/alphabetic_bullets_spec.rb
+++ b/spec/alphabetic_bullets_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe 'Bullets.vim' do
       TEXT
 
       vim.edit filename
+      vim.command('let g:bullets_renumber_on_change=0')
       vim.type 'GA'
       vim.feedkeys '\<cr>'
       vim.type 'second bullet'
@@ -184,6 +185,7 @@ RSpec.describe 'Bullets.vim' do
         TEXT
 
         vim.edit filename
+        vim.command('let g:bullets_renumber_on_change=0')
         vim.type 'GA'
         vim.feedkeys '\<cr>'
         vim.type 'second bullet'

--- a/spec/bullets_spec.rb
+++ b/spec/bullets_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe 'Bullets.vim' do
       end
 
       it 'maintains total bullet width from 9. to 10. with reduced padding' do
+        vim.command('let g:bullets_renumber_on_change=0')
         test_bullet_inserted('second bullet', <<-INIT, <<-EXPECTED)
           # Hello there
           9.  this is the first bullet

--- a/spec/nested_bullets_spec.rb
+++ b/spec/nested_bullets_spec.rb
@@ -29,13 +29,17 @@ RSpec.describe 'Bullets.vim' do
       vim.normal 'j'
       vim.feedkeys '>>>>>>>>>>'
       vim.normal 'j'
-      vim.feedkeys '>>>>>>>>>>>>'
+      vim.feedkeys '>>>>>>>>'
+      vim.feedkeys '>>>>'
       vim.normal 'j'
-      vim.feedkeys '>>>>>>>>>>>>>>'
+      vim.feedkeys '>>>>>>>>'
+      vim.feedkeys '>>>>>>'
       vim.normal 'j'
-      vim.feedkeys '>>>>>>>>>>>>>>>>'
+      vim.feedkeys '>>>>>>>>'
+      vim.feedkeys '>>>>>>>>'
       vim.normal 'j'
-      vim.feedkeys '>>>>>>>>>>>>>>>>>>'
+      vim.feedkeys '>>>>>>>>'
+      vim.feedkeys '>>>>>>>>>>'
       vim.write
 
       file_contents = IO.read(filename)
@@ -78,13 +82,18 @@ RSpec.describe 'Bullets.vim' do
       vim.normal 'j'
       vim.feedkeys '<<<<<<'
       vim.normal 'j'
-      vim.feedkeys '<<<<<<<<<<'
+      vim.feedkeys '<<<<<<'
+      vim.feedkeys '<<<<'
       vim.normal 'j'
-      vim.feedkeys '<<<<<<<<<<<<'
+      vim.feedkeys '<<<<<<'
+      vim.feedkeys '<<<<<<'
       vim.normal 'j'
-      vim.feedkeys '<<<<<<<<<<<<<<'
+      vim.feedkeys '<<<<<<'
+      vim.feedkeys '<<<<<<<<'
       vim.normal 'j'
-      vim.feedkeys '<<<<<<<<<<<<<<<<'
+      vim.feedkeys '<<<<<<'
+      vim.feedkeys '<<<<<<'
+      vim.feedkeys '<<<<'
       vim.write
 
       file_contents = IO.read(filename)
@@ -633,11 +642,13 @@ RSpec.describe 'Bullets.vim' do
       vim.normal 'jvj'
       vim.feedkeys '>'
       vim.normal 'jvj'
-      vim.feedkeys '<<'
+      vim.feedkeys '<'
+      vim.feedkeys '<'
       vim.normal 'jv'
       vim.feedkeys '>'
       vim.normal '3jv2j'
-      vim.feedkeys '>>'
+      vim.feedkeys '>'
+      vim.feedkeys '>'
       vim.write
 
       file_contents = IO.read(filename)

--- a/spec/nested_bullets_spec.rb
+++ b/spec/nested_bullets_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Bullets.vim' do
           \t\t\t\t\t\t- sixth bullet
           \t\t\t\t\t\t\t* seventh bullet
           \t\t\t\t\t\t\t\t+ eighth bullet
-          \t\t\t\t\t\t\t\t\tninth bullet
+          \t\t\t\t\t\t\t\t\t+ ninth bullet
 
       TEXT
     end
@@ -290,17 +290,18 @@ RSpec.describe 'Bullets.vim' do
       vim.type 'sixth bullet'
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-t>'
-      vim.type 'not a bullet'
-      vim.feedkeys '\<cr>'
       vim.type 'seventh bullet'
       vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-d>'
       vim.type 'eighth bullet'
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-d>'
+      vim.feedkeys '\<C-d>'
       vim.type 'ninth bullet'
       vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-d>'
       vim.type 'tenth bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'eleventh bullet'
 
       vim.write
 
@@ -314,11 +315,11 @@ RSpec.describe 'Bullets.vim' do
           \tB. fourth bullet
           \t\t* fifth bullet
           \t\t* sixth bullet
-          \t\t\tnot a bullet
-          \t\t* seventh bullet
-          \tC. eighth bullet
-          3. ninth bullet
-          4. tenth bullet
+          \t\t\t* seventh bullet
+          \t\t\t* eighth bullet
+          \tC. ninth bullet
+          3. tenth bullet
+          4. eleventh bullet
 
       TEXT
     end
@@ -356,15 +357,16 @@ RSpec.describe 'Bullets.vim' do
       vim.type '+ sixth bullet'
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-t>'
-      vim.type 'not a bullet'
-      vim.feedkeys '\<cr>'
       vim.type 'seventh bullet'
       vim.feedkeys '\<cr>'
+      vim.type 'eighth bullet'
+      vim.feedkeys '\<C-d>'
       vim.feedkeys '\<cr>'
-      vim.type '* eighth bullet'
+      vim.feedkeys '\<cr>'
+      vim.type '* ninth bullet'
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-t>'
-      vim.type 'ninth bullet'
+      vim.type 'tenth bullet'
 
       vim.write
 
@@ -380,16 +382,16 @@ RSpec.describe 'Bullets.vim' do
           \tb. fifth bullet
 
           + sixth bullet
-          \tnot a bullet
-          + seventh bullet
+          \t+ seventh bullet
+          + eighth bullet
 
-          * eighth bullet
-          \t+ ninth bullet
+          * ninth bullet
+          \t+ tenth bullet
 
       TEXT
     end
 
-    it 'does not nest below defined levels' do
+    it 'does not nest further below defined levels' do
       filename = "#{SecureRandom.hex(6)}.txt"
       write_file(filename, <<-TEXT)
           # Hello there
@@ -408,9 +410,9 @@ RSpec.describe 'Bullets.vim' do
       vim.normal 'GA'
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-t>'
-      vim.type 'not a bullet'
-      vim.feedkeys '\<cr>'
       vim.type 'tenth bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'eleventh bullet'
       vim.write
 
       file_contents = IO.read(filename)
@@ -426,8 +428,8 @@ RSpec.describe 'Bullets.vim' do
           \t\t\t\t\t- seventh bullet
           \t\t\t\t\t\t* eighth bullet
           \t\t\t\t\t\t\t+ ninth bullet
-          \t\t\t\t\t\t\t\tnot a bullet
-          \t\t\t\t\t\t\t+ tenth bullet
+          \t\t\t\t\t\t\t\t+ tenth bullet
+          \t\t\t\t\t\t\t\t+ eleventh bullet
 
       TEXT
     end
@@ -596,6 +598,68 @@ RSpec.describe 'Bullets.vim' do
           \t\t\t\twrapped line
 
           \t\t\td. eighteenth bullet
+
+      TEXT
+    end
+
+    it 'changes levels in visual mode' do
+      filename = "#{SecureRandom.hex(6)}.txt"
+      write_file(filename, <<-TEXT)
+          # Hello there
+          1. first bullet
+          \ta. second bullet
+          \tb. third bullet
+          \t\t* fourth bullet
+          \t\t* fifth bullet
+          \t\t\tsixth bullet
+          \t\t* seventh bullet
+          2. eighth bullet
+          \t\ta. ninth bullet
+          \ta. tenth bullet
+          \tb. eleventh bullet
+          3. twelfth bullet
+          \t thirteenth bullet
+          \ta. fourteenth bullet
+          \t\t* fifteenth bullet
+          4. sixteenth bullet
+      TEXT
+
+      vim.edit filename
+      vim.command "let g:bullets_outline_levels=['num','abc','std*']"
+      vim.normal '3jv'
+      vim.feedkeys '<'
+      vim.normal 'jv2j'
+      vim.feedkeys '<'
+      vim.normal 'jvj'
+      vim.feedkeys '>'
+      vim.normal 'jvj'
+      vim.feedkeys '<<'
+      vim.normal 'jv'
+      vim.feedkeys '>'
+      vim.normal '3jv2j'
+      vim.feedkeys '>>'
+      vim.write
+
+      file_contents = IO.read(filename)
+
+      expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+          # Hello there
+          1. first bullet
+          \ta. second bullet
+          2. third bullet
+          \ta. fourth bullet
+          \tb. fifth bullet
+          \t\tsixth bullet
+          \t\t\t* seventh bullet
+          \tc. eighth bullet
+          3. ninth bullet
+          tenth bullet
+          \t\ta. eleventh bullet
+          4. twelfth bullet
+          \t thirteenth bullet
+          \t\t\ta. fourteenth bullet
+          \t\t\t\t* fifteenth bullet
+          \t\ta. sixteenth bullet
 
       TEXT
     end

--- a/spec/renumber_bullets_spec.rb
+++ b/spec/renumber_bullets_spec.rb
@@ -33,19 +33,20 @@ RSpec.describe 're-numbering' do
     filename = "#{SecureRandom.hex(6)}.txt"
     write_file(filename, <<-TEXT)
       # Hello there
+      0. zero bullet
       X. first bullet
-      V. second bullet
+      - second bullet
       3. third bullet
       I. fourth bullet
       V. fifth bullet
       \tB. sixth bullet
-      \tB. seventh bullet
+      \t* seventh bullet
       \t\ti. eighth bullet
       \t\tx. ninth bullet
       \t\ta. tenth bullet
       \tC. eleventh bullet
       \t\t1. twelfth bullet
-      \t\t1. thirteenth bullet
+      \t\t\t thirteenth not a bullet
       \t\t1. fourteenth bullet
       \td. fifteenth bullet
       \t\ta. sixteenth bullet
@@ -60,11 +61,12 @@ RSpec.describe 're-numbering' do
       \t\t\t\t\t- twenty-fifth bullet
       \tII. twenty-sixth bullet
       \t\t- twenty-seventh bullet
-      0. twenty-eighth bullet
+      i. twenty-eighth bullet
+      0. twenty-ninth bullet
     TEXT
 
     vim.edit filename
-    vim.type 'ggVG'
+    vim.type '2jVGk'
     vim.feedkeys 'gN'
     vim.write
 
@@ -72,6 +74,7 @@ RSpec.describe 're-numbering' do
 
     expect(file_contents).to eq normalize_string_indent(<<-TEXT)
       # Hello there
+      0. zero bullet
       I. first bullet
       II. second bullet
       III. third bullet
@@ -84,8 +87,8 @@ RSpec.describe 're-numbering' do
       \t\tiii. tenth bullet
       \tC. eleventh bullet
       \t\t1. twelfth bullet
-      \t\t2. thirteenth bullet
-      \t\t3. fourteenth bullet
+      \t\t\t thirteenth not a bullet
+      \t\t2. fourteenth bullet
       \tD. fifteenth bullet
       \t\ta. sixteenth bullet
       \t\t\t1. seventeenth bullet
@@ -100,6 +103,7 @@ RSpec.describe 're-numbering' do
       \tE. twenty-sixth bullet
       \t\t- twenty-seventh bullet
       VI.  twenty-eighth bullet
+      0. twenty-ninth bullet
 
     TEXT
   end

--- a/spec/renumber_bullets_spec.rb
+++ b/spec/renumber_bullets_spec.rb
@@ -29,40 +29,188 @@ RSpec.describe 're-numbering' do
     TEXT
   end
 
-  it 'renumbers a nested list correctly' do
+  it 'visually renumbers a nested list' do
     filename = "#{SecureRandom.hex(6)}.txt"
     write_file(filename, <<-TEXT)
       # Hello there
       0. zero bullet
+
       X. first bullet
+
       - second bullet
-      3. third bullet
+      \twrapped line
+
+      a. third bullet
+
       I. fourth bullet
-      V. fifth bullet
-      \tB. sixth bullet
+
+      \tV. fifth bullet
+
+      \t\tB. sixth bullet
+
       \t* seventh bullet
+
       \t\ti. eighth bullet
+
       \t\tx. ninth bullet
-      \t\ta. tenth bullet
+      \t\t\t wrapped line
+
+      \t\t\ta. tenth bullet
+      wrapped line without indent
+
       \tC. eleventh bullet
-      \t\t1. twelfth bullet
-      \t\t\t thirteenth not a bullet
-      \t\t1. fourteenth bullet
-      \td. fifteenth bullet
+      \t\t0. twelfth bullet
+
+      \t\t\t* thirteenth bullet
+
+      \t\t\t\t+ fourteenth bullet
+
+      \t\t\td. fifteenth bullet
+
       \t\ta. sixteenth bullet
+
       \t\t\t8. seventeenth bullet
+
       \t\t\t0. eighteenth bullet
-      \t\t\t\tv. nineteenth bullet
-      \t\t\t\ti. twentieth bullet
-      \t\t\t\ti. twenty-first bullet
-      \t\t\tc. twenty-second bullet
-      \t\t\t\tX. twenty-third bullet
-      \t\t\t\t\t- twenty-fourth bullet
-      \t\t\t\t\t- twenty-fifth bullet
-      \tII. twenty-sixth bullet
-      \t\t- twenty-seventh bullet
-      i. twenty-eighth bullet
-      0. twenty-ninth bullet
+      \t\t\t\t wrapped line
+
+      \tnormal indented line
+      next normal line
+
+      1. nineteenth bullet
+      x. twentieth bullet
+
+      v. twenty-first bullet
+      - twenty-second bullet
+
+
+      v. twenty-third bullet
+    TEXT
+
+    vim.edit filename
+    vim.command 'let g:bullets_line_spacing=2'
+    vim.normal '3jVG19k'
+    vim.feedkeys 'gN'
+    vim.normal 'GV6k'
+    vim.feedkeys 'gN'
+    vim.write
+
+    file_contents = IO.read(filename)
+
+    expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+      # Hello there
+      0. zero bullet
+
+      I. first bullet
+
+      II. second bullet
+      \twrapped line
+
+      III. third bullet
+
+      IV.  fourth bullet
+
+      \tI. fifth bullet
+
+      \t\tA. sixth bullet
+
+      \tII. seventh bullet
+
+      \t\ta. eighth bullet
+
+      \t\tb. ninth bullet
+      \t\t\t wrapped line
+
+      \t\t\ta. tenth bullet
+      wrapped line without indent
+
+      \tIII. eleventh bullet
+      \t\t1. twelfth bullet
+
+      \t\t\t* thirteenth bullet
+
+      \t\t\t\t+ fourteenth bullet
+
+      \t\t\t* fifteenth bullet
+
+      \t\ta. sixteenth bullet
+
+      \t\t\t8. seventeenth bullet
+
+      \t\t\t0. eighteenth bullet
+      \t\t\t\t wrapped line
+
+      \tnormal indented line
+      next normal line
+
+      1. nineteenth bullet
+      i. twentieth bullet
+
+      ii. twenty-first bullet
+      iii. twenty-second bullet
+
+
+      iv.  twenty-third bullet
+
+    TEXT
+  end
+
+  it 'renumbers a nested list' do
+    filename = "#{SecureRandom.hex(6)}.txt"
+    write_file(filename, <<-TEXT)
+      # Hello there
+      0. zero bullet
+
+      X. first bullet
+
+      - second bullet
+      \twrapped line
+
+      a. third bullet
+
+      I. fourth bullet
+
+      \tV. fifth bullet
+
+      \t\tB. sixth bullet
+
+      \t* seventh bullet
+
+      \t\ti. eighth bullet
+
+      \t\tx. ninth bullet
+      \t\t\t wrapped line
+
+      \t\t\ta. tenth bullet
+      wrapped line without indent
+
+      \tC. eleventh bullet
+      \t\t0. twelfth bullet
+
+      \t\t\t* thirteenth bullet
+
+      \t\t\t\t+ fourteenth bullet
+
+      \t\t\td. fifteenth bullet
+
+      \t\ta. sixteenth bullet
+
+      \t\t\t8. seventeenth bullet
+
+      \t\t\t0. eighteenth bullet
+      \t\t\t\t wrapped line
+
+      \tnormal indented line
+      next normal line
+
+      1. nineteenth bullet
+      x. twentieth bullet
+
+      v. twenty-first bullet
+      - twenty-second bullet
+
+
+      v. twenty-third bullet
     TEXT
 
     vim.edit filename
@@ -75,35 +223,57 @@ RSpec.describe 're-numbering' do
     expect(file_contents).to eq normalize_string_indent(<<-TEXT)
       # Hello there
       0. zero bullet
+
       I. first bullet
+
       II. second bullet
+      \twrapped line
+
       III. third bullet
+
       IV.  fourth bullet
-      V.   fifth bullet
-      \tA. sixth bullet
-      \tB. seventh bullet
+
+      \tI. fifth bullet
+
+      \t\tA. sixth bullet
+
+      \tII. seventh bullet
+
       \t\ti. eighth bullet
+
       \t\tii. ninth bullet
-      \t\tiii. tenth bullet
-      \tC. eleventh bullet
+      \t\t\t wrapped line
+
+      \t\t\ta. tenth bullet
+      wrapped line without indent
+
+      \tIII. eleventh bullet
       \t\t1. twelfth bullet
-      \t\t\t thirteenth not a bullet
-      \t\t2. fourteenth bullet
-      \tD. fifteenth bullet
-      \t\ta. sixteenth bullet
+
+      \t\t\t* thirteenth bullet
+
+      \t\t\t\t+ fourteenth bullet
+
+      \t\t\t* fifteenth bullet
+
+      \t\t2. sixteenth bullet
+
       \t\t\t1. seventeenth bullet
+
       \t\t\t2. eighteenth bullet
-      \t\t\t\ti. nineteenth bullet
-      \t\t\t\tii. twentieth bullet
-      \t\t\t\tiii. twenty-first bullet
-      \t\t\t3. twenty-second bullet
-      \t\t\t\tI. twenty-third bullet
-      \t\t\t\t\t- twenty-fourth bullet
-      \t\t\t\t\t- twenty-fifth bullet
-      \tE. twenty-sixth bullet
-      \t\t- twenty-seventh bullet
-      VI.  twenty-eighth bullet
-      0. twenty-ninth bullet
+      \t\t\t\t wrapped line
+
+      \tnormal indented line
+      next normal line
+
+      V.   nineteenth bullet
+      VI.  twentieth bullet
+
+      VII. twenty-first bullet
+      VIII. twenty-second bullet
+
+
+      v. twenty-third bullet
 
     TEXT
   end

--- a/spec/renumber_bullets_spec.rb
+++ b/spec/renumber_bullets_spec.rb
@@ -28,4 +28,79 @@ RSpec.describe 're-numbering' do
       4.  this is the fourth bullet\n
     TEXT
   end
+
+  it 'renumbers a nested list correctly' do
+    filename = "#{SecureRandom.hex(6)}.txt"
+    write_file(filename, <<-TEXT)
+      # Hello there
+      X. first bullet
+      V. second bullet
+      3. third bullet
+      I. fourth bullet
+      V. fifth bullet
+      \tB. sixth bullet
+      \tB. seventh bullet
+      \t\ti. eighth bullet
+      \t\tx. ninth bullet
+      \t\ta. tenth bullet
+      \tC. eleventh bullet
+      \t\t1. twelfth bullet
+      \t\t1. thirteenth bullet
+      \t\t1. fourteenth bullet
+      \td. fifteenth bullet
+      \t\ta. sixteenth bullet
+      \t\t\t8. seventeenth bullet
+      \t\t\t0. eighteenth bullet
+      \t\t\t\tv. nineteenth bullet
+      \t\t\t\ti. twentieth bullet
+      \t\t\t\ti. twenty-first bullet
+      \t\t\tc. twenty-second bullet
+      \t\t\t\tX. twenty-third bullet
+      \t\t\t\t\t- twenty-fourth bullet
+      \t\t\t\t\t- twenty-fifth bullet
+      \tII. twenty-sixth bullet
+      \t\t- twenty-seventh bullet
+      0. twenty-eighth bullet
+    TEXT
+
+    vim.edit filename
+    vim.type 'ggVG'
+    vim.feedkeys 'gN'
+    vim.write
+
+    file_contents = IO.read(filename)
+
+    expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+      # Hello there
+      I. first bullet
+      II. second bullet
+      III. third bullet
+      IV.  fourth bullet
+      V.   fifth bullet
+      \tA. sixth bullet
+      \tB. seventh bullet
+      \t\ti. eighth bullet
+      \t\tii. ninth bullet
+      \t\tiii. tenth bullet
+      \tC. eleventh bullet
+      \t\t1. twelfth bullet
+      \t\t2. thirteenth bullet
+      \t\t3. fourteenth bullet
+      \tD. fifteenth bullet
+      \t\ta. sixteenth bullet
+      \t\t\t1. seventeenth bullet
+      \t\t\t2. eighteenth bullet
+      \t\t\t\ti. nineteenth bullet
+      \t\t\t\tii. twentieth bullet
+      \t\t\t\tiii. twenty-first bullet
+      \t\t\t3. twenty-second bullet
+      \t\t\t\tI. twenty-third bullet
+      \t\t\t\t\t- twenty-fourth bullet
+      \t\t\t\t\t- twenty-fifth bullet
+      \tE. twenty-sixth bullet
+      \t\t- twenty-seventh bullet
+      VI.  twenty-eighth bullet
+
+    TEXT
+  end
 end


### PR DESCRIPTION
Adds the following:
* renumbering for nested lists
* renumbering the entire list containing the cursor (gN in normal mode)
* automatic renumbering of the current list when promoting/demoting (optional via g:bullets_renumber_on_change)
* visual mode promoting and demoting of bullets
* automatic renumbering when inserting a new bullet
* additional tests for new functionality (still needs better coverage)

Fixes the following:
* changes the functionality of indenting when outside of the defined bullet levels: keeps the existing bullet and just indents instead of deleting the bullet since the previous behavior is more unexpected than just indenting.
* code cleanup
* update README and documentation