### PR TITLE
check if bullet is lower only if bullet key exists

### DIFF
--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -630,7 +630,12 @@ fun! s:change_bullet_level(direction)
     return
   endif
 
-  let l:islower = l:closest_bullet.bullet ==# tolower(l:closest_bullet.bullet)
+  if has_key(l:closest_bullet, "bullet")
+      let l:islower = l:closest_bullet.bullet ==# tolower(l:closest_bullet.bullet)
+  else
+      let l:islower = 1
+  endif
+
   let l:closest_type = l:islower ? l:closest_bullet.bullet_type :
         \ toupper(l:closest_bullet.bullet_type)
 


### PR DESCRIPTION
This fixes issue #59, checking if `bullet` is lower case only when the key `bullet` exist in the dictionary `l:closest_bullet`. Feel free to reject in case it should be fixed in a different way.