### PR TITLE
Vimwiki checkboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,12 @@ Capybara integration testing. ❤️
 - [x] detect lists that have multiline bullets (should have no empty lines between
   lines).
 - [x] add alphabetic list
-- [ ] support for intelligent alphanumeric indented bullets e.g. 1. \t a. \t 1.
+- [x] support for intelligent alphanumeric indented bullets e.g. 1. \t a. \t 1.
+- [ ] update documentation for nested bullets
+- [ ] support for nested numerical bullets, e.g., 1. -> 1.1 -> 1.1.1, 1.1.2
+- [ ] change nested outline levels in visual mode
+- [ ] support renumbering of alphabetical, roman numerals, and nested lists
+- [ ] add option to turn non-bullet lines into new bullets with `C-t`/`>>`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ to go to the next line, a new list item will be created.
 
 # Configuration
 
+### Filetypes
+
 You can choose which file types this plugin will work on:
 
 ```vim
@@ -44,6 +46,219 @@ let g:bullets_enabled_file_types = [
     \ 'gitcommit',
     \ 'scratch'
     \]
+```
+
+You can disable this plugin for empty buffers (no filetype):
+
+```vim
+let g:bullets_enable_in_empty_buffers = 0 " default = 1
+```
+
+Enable/disable default key mappings:
+
+```vim
+let g:bullets_set_mappings = 0 " default = 1
+```
+
+Add a leader key before default mappings:
+
+```vim
+let g:bullets_mapping_leader = '<M-b>' " default = ''
+```
+
+Enable/disable deleting the last empty bullet when hitting `<cr>` (insert mode) or `o` (normal mode):
+
+```vim
+let g:bullets_delete_last_bullet_if_empty = 0 " default = 1
+```
+
+Line spacing between bullets (1 = no blank lines, 2 = one blank line, etc.):
+
+```vim
+let g:bullets_line_spacing = 2 " default = 1
+```
+
+Don't/add extra padding between the bullet and text when bullets are multiple characters long:
+
+```vim
+let g:bullets_pad_right = 1 " default = 1
+" I. text
+" II. text
+" III. text
+" IV.  text
+" V.   text
+"     ^ extra spaces to align the text with the longest bullet
+
+let g:bullets_pad_right = 0
+" I. text
+" II. text
+" III. text
+" IV. text
+"    ^ no extra space between bullet and text
+```
+
+Maximum number of alphabetic characters to use for bullets:
+
+```vim
+let g:bullets_max_alpha_characters = 2 " default = 2
+" ...
+" y. text
+" z. text
+" aa. text
+" ab. text
+
+let g:bullets_max_alpha_characters = 1
+" ...
+" y. text
+" z. text
+" text
+```
+
+Nested outline bullet levels:
+
+```vim
+let g:bullets_outline_levels = ['ROM', 'ABC', 'num', 'abc', 'rom', 'std-', 'std*', 'std+'] " default
+" Ordered list containing the heirarchical bullet levels, starting from the outer most level.
+" Available bullet level options (cannot use the same marker more than once)
+" ROM/rom = upper/lower case Roman numerals (e.g., I, II, III, IV)
+" ABC/abc = upper/lower case alphabetic characters (e.g., A, B, C)
+" std[-/*/+] = standard bullets using a hyphen (-), asterisk (*), or plus (+) as the marker.
+" chk = checkbox (- [ ])
+
+let g:bullets_outline_levels = ['num', 'abc', 'std*']
+" Example [keys pressed to get this bullet]:
+" 1. first parent
+"   a. child bullet [ <cr><C-t> ]
+"     - unordered bullet [ <cr><C-t> ]
+"   b. second child bullet [ <cr><C-d> ]
+" 2. second parent [ <cr><C-d> ]
+```
+
+Enable/disable automatically renumbering the current ordered bullet list when changing the indent level of bullets or inserting a new bullet:
+
+```vim
+let g:bullets_renumber_on_change = 1 " default = 1
+" Example 1:
+" 1. first existing bullet
+"   a. second existing bullet [ hit <C-t> ]
+" 2. third existing bullet [ this got renumbered 3 -> 2 when bullet 2 got demoted ]
+"
+" Example 2:
+" 1. first existing bullet
+" 2. second existing bullet [ use <cr>/o to add a new bullet below this ]
+" 3. new bullet
+" 4. third existing bullet [ this got renumbered 3 -> 2 when bullet 2 got demoted ]
+
+let g:bullets_renumber_on_change = 0
+" Example:
+" 1. first existing bullet
+"   a. second existing bullet [ hit <C-t> ]
+" 3. third existing bullet [ no renumbering so this bullet remained `3` ]
+"
+" Example 2:
+" 1. first existing bullet
+" 2. second existing bullet [ use <cr>/o to add a new bullet below this ]
+" 3. new bullet
+" 3. third existing bullet [ no renumbering so this bullet remained `3` ]
+```
+
+Enable/disable toggling parent and child checkboxes to indicate "completion" of child checkboxes:
+
+```vim
+let g:bullets_nested_checkboxes = 1 " default = 1
+" Example:
+" - [ ] first bullet
+"   - [ ] child bullet  [ type <leader>x ]
+"     - [ ] sub-child
+"   - [ ] child bullet
+" 
+" Result:
+" - [o] first bullet   [ <- indicates partial completion of sub-tasks ]
+"   - [X] child bullet
+"     - [X] sub-child  [ <- children get checked when parents get checked ]
+"   - [ ] child bullet
+```
+
+Define the checkbox markers to use to indicate unchecked, checked, and "partially" checked. When only two marker characters are defined, the use of partial completion markers will be disabled. If more than two markers are defined, each character between the first and last characters will be used to indicate a percentage of the child checkboxes that are checked. Each marker corresponds to 1/n, where n is the number of partial completion markers. By default, there are three partial completion markers, `.`, `o`, and `O`, corresponding to 33%, 66%, and up to but less than 100%, respectively. Note that unchecked (`[ ]`) and checked (`[x]` or `[X]`) statuses using the default markers are always valid, even if you set custom markers for unchecked and checked.
+
+```vim
+let g:bullets_checkbox_markers = ' .oOX'
+" Example:
+" - [o] parent bullet  [ <- `o` indicates 66% - 99% of children are checked ]
+"   - [ ] child bullet
+"   - [.] child bullet [ <- partial completions don't count as complete ]
+"     - [ ] sub-child bullet [ <- 1/4 of children checked so parent is `.` ]
+"     - [ ] sub-child bullet
+"     - [ ] sub-child bullet
+"     - [X] sub-child bullet
+"   - [X] child bullet
+"   - [X] child bullet
+"
+" You can use fancy markers:
+" let g:bullets_checkbox_markers = '✗○◐●✓'
+" - [✗] unchecked
+" - [○] partial
+"   - [✓] checked
+"   - [✗] unchecked
+"   - [✗] unchecked
+"   - [✗] unchecked
+```
+
+Define whether toggling partially complete checkboxes sets the checkbox to checked or unchecked:
+
+```vim
+" Example 1:
+let g:bullets_checkbox_partials_toggle = 1 " default = 1
+" - [o] partially checked  [ type <leader>x ]
+"   - [x] sub bullet
+"   - [ ] sub bullet
+" 
+" Result:
+" - [x] checked
+"   - [x] sub bullet
+"   - [x] sub bullet
+" 
+" Example 2:
+let g:bullets_checkbox_partials_toggle = 0
+" - [o] partially checked  [ type <leader>x ]
+"   - [x] sub bullet
+"   - [ ] sub bullet
+" 
+" Result:
+" - [ ] checked
+"   - [ ] sub bullet
+"   - [ ] sub bullet
+```
+
+# Mappings
+
+* Insert new bullet in INSERT mode: `<cr>` (Return key)
+* Same as <cr> in case you want to unmap <cr> in INSERT mode (compatibility depends on your terminal emulator): `<C-cr>`
+* Insert new bullet in NORMAL mode: `o`
+* Renumber current visual selection: `gN`
+* Renumber entire bullet list containing the cursor in NORMAL mode: gN
+* Toggle a checkbox in NORMAL mode: `<leader>x`
+* Demote a bullet (indent it, decrease bullet level, and make it a child of the previous bullet):
+  + NORMAL mode: `>>`
+  + INSERT mode: `<C-t>`
+  + VISUAL mode: `>`
+* Promote a bullet (unindent it and increase the bullet level):
+  + NORMAL mode: `<<`
+  + INSERT mode: `<C-d>`
+  + VISUAL mode: `>`
+
+Disable default mappings:
+
+```vim
+let g:bullets_set_mappings = 0
+```
+
+Add a leader key before default mappings:
+
+```vim
+let g:bullets_mapping_leader = '<M-b>' 
+" Set <M-b> to the leader before all default mappings:
+" Example: renumbering becomes `<M-b>gN` instead of just `gN`
 ```
 
 Just add above to your .vimrc
@@ -93,11 +308,12 @@ Capybara integration testing. ❤️
   lines).
 - [x] add alphabetic list
 - [x] support for intelligent alphanumeric indented bullets e.g. 1. \t a. \t 1.
-- [ ] update documentation for nested bullets
+- [x] change nested outline levels in visual mode
+- [x] support renumbering of alphabetical, roman numerals, and nested lists
+- [x] update documentation for nested bullets
+- [x] support nested bullets with child and partial completion
 - [ ] support for nested numerical bullets, e.g., 1. -> 1.1 -> 1.1.1, 1.1.2
-- [ ] change nested outline levels in visual mode
-- [ ] support renumbering of alphabetical, roman numerals, and nested lists
-- [ ] add option to turn non-bullet lines into new bullets with `C-t`/`>>`
+- [ ] add option to turn non-bullet lines into new bullets with `<C-t>`/`>>`/`>`
 
 ---
 

--- a/doc/bullets.txt
+++ b/doc/bullets.txt
@@ -10,7 +10,7 @@ TABLE OF CONTENTS                         *bullets-toc*
 |bullets-configuration|            Configuration
 |bullets-insert-new-bullet|        Inserting Bullets
 |bullets-indenting|                Indenting Bullets
-|bullets-checkboxes|               Gfm Markdown Checkboxes
+|bullets-checkboxes|               Gfm/vimwiki Markdown Checkboxes
 |bullets-mappings|                 Mappings
 
 
@@ -27,13 +27,19 @@ types:
 
 - Hyphenated lists
 * Star (or bullet) lists
-- [ ] GFM markdown checkbox lists
++ Plus (also bullet) lists
+- [ ] GFM/vimwiki markdown checkbox lists
 1. Numeric lists
 2) or this style of numeric lists
 a. alphabetic lists
 B) or this style of alphabetic
+i. Roman numeral lists
+II. or capitalized Roman numeral lists
 \item latex item lists
 **** Org mode headers
+
+It supports nested (heirarchical) ordered lists/outlines using different types
+of bullet markers for each level.
 
 It also provides support for wrapped text in a bullet, allowing you to use the
 `textwidth` feature in Vim seamlessly.
@@ -71,6 +77,30 @@ GENERAL COMMANDS                            *bullets-commands*
 :RenumberSelection     Renumbers all the arabic/numeric bullets lines in the
                        visual selection. Right padding is initalized to the
                        first found bullet.
+
+                                            *bullets-:RenumberList*
+:RenumberList          Renumbers all of the bullet lines in the current list.
+                       A blank line before/after the first/last bullet denotes
+                       the end of the list.
+
+                                            *bullets-:BulletDemote*
+:BulletDemote          Demotes the current bullet by indenting it and changing
+                       its bullet type to the next level defined in 
+                       g:bullets_outline_levels. Mapped to <C-t> in INSERT
+                       mode and `>>` in NORMAL mode.
+
+                                            *bullets-:BulletPromote*
+:BulletPromote         Promotes the current bullet by unindenting it and 
+                       changing its bullet type to the next level defined in 
+                       g:bullets_outline_levels. Mapped to <C-d> in INSERT
+                       mode and `<<` in NORMAL mode by default.
+
+                                            *bullets-:BulletDemoteVisual*
+:BulletDemoteVisual    Demotes the currently selected bullet(s) in VISUAL
+                       mode. Mapped to `>` in VISUAL mode by default.
+                                            *bullets-:BulletPromoteVisual*
+:BulletPromoteVisual   Promotes the currently selected bullet(s) in VISUAL
+                       mode. Mapped to `>` in VISUAL mode by default.
 
 CONFIGURATION                               *bullets-configuration*
 
@@ -161,6 +191,89 @@ that using auto commands.
 When changed to `0` this will disable alphabetic bullets altogether.
 
 
+Nested Outline Bullet Levels
+----------------------------
+You can create heirarchically nested outlines using indentation and different
+bullet types for each level of indentation. Define the type of bullet used for
+each level using the following ordered list:
+
+   `let g:bullets_outline_levels = ['ROM', 'ABC', 'num', 'abc', 'rom', 'std-',`
+  `   \ 'std*', 'std+']`
+
+Demoting a bullet ([I]<C-t>, [N]`>>`, [V]`>`) will increase its indentation and use the
+next bullet level defined in this list. Similarly, promoting the bullet
+([I]<C-d>, [N]`<<`, [V]`<`) will decrease the bullet
+indentation and use the previous bullet level. Promoting a top-level bullet
+will remove the bullet and demoting a bottom-level bullet will indent, but not
+change the bullet marker.
+
+
+Renumber Bullets on Change
+--------------------------
+By default, inserting a new bullet or promoting/demoting an existing bullet in
+the middle of a list will cause all of the list items, including nested
+bullets, to be renumbered. You can disable renumbering using the following:
+
+  `let g:bullets_renumber_on_change = 0`
+
+The current list is defined by blank lines surrounding the first/last bullet
+items, taking into consideration the setting in g:bullets_line_spacing.
+
+You can always manually renumber the current list or visual selection using
+`gN` in NORMAL or VISUAL mode.
+
+
+Toggle Parent and Child Checkboxes
+----------------------------------
+If a checkbox has child checkboxes, checking the checkbox will check all
+its children, and unchecking it will uncheck all its children. When toggling
+a child checkbox, the parent will be checked, unchecked, or marked with
+a partial completion marker (see |bullets-checkboxes|). You can disable this
+behavior using the following:
+
+  `let g:bullets_nested_checkboxes = 0`
+
+
+Checkbox Marker and Partial Completion Symbols
+----------------------------------------------
+In addition to the GFM markdown checkbox symbols, ` ` (unchecked) and `x`
+(checked), you can define and use custom marker symbols. You can also define
+and use marker symbols indicating partial completion of child checkboxes,
+like vimwiki syntax. By default, three symbols are defined for 1%-33% complete
+(`.`), 34%-66% complete (`o`), and 67%-99% complete (`O`), with 0% and 100%
+completion indicated by the unchecked and checked markers, respectively.
+
+The marker symbols are defined in a text string consisting of the sequential
+markers to use for unckecked (first character), partially checked (0+ middle
+characters), and checked (last character) statuses:
+
+  `let g:bullets_checkbox_markers = ' .oOX'`
+
+You can define fewer or more intermediate characters for partial completion,
+and the completion intervals will be adjusted accordingly.
+
+If you only define a checked and unchecked marker symbol, partial completion
+will be disabled:
+
+  `let g:bullets_checkbox_markers = ' X'`
+
+The standard GFM marker symbols for checked and unchecked (` ` and `x`) will
+always work for compatibility purposes, even when you use custom marker symbols.
+
+You can also use fancy marker symbols, for example:
+
+  `let g:bullets_checkbox_markers = '✗○◐●✓'`
+
+
+Toggling Partially Checked Checkboxes
+-------------------------------------
+You can define whether toggling a partially checked checkbox will result in it
+being marked checked (1, default) or unchecked (0):
+
+
+  `let g:bullets_checkbox_partials_toggle = 1`
+
+
 INSERTING BULLETS                           *bullets-insert-new-bullet*
 
 When a supported file type is opened (see |bullets-configuration|) you can start
@@ -184,18 +297,24 @@ Vim comes built in with support for indenting and de-indenting in INSERT mode.
 To indent the current bullet to the right: from insert mode press <CTRL-t>.
 To indent the current bullet to the left: from insert mode press <CTRL-d>.
 
-Note: For <CTRL-d> to work properly you have to be at the end of the line.
-
 For more information `:h i_CTRL-T` and `:h i_CTRL-D`
 
 
-GFM MARKDOWN CHECKBOXES                     *bullets-checkboxes*
+GFM AND VIMWIKI MARKDOWN CHECKBOXES         *bullets-checkboxes*
 
-Bullets.vim supports checking and unchecking GFM markdown checkboxes. While in
-normal mode, move over a checkbox list item (anywhere on the item) and use
-<leader>x to toggle the checkbox state.
+Bullets.vim supports checking and unchecking GFM- and vimwiki-style markdown
+checkboxes. While in normal mode, move over a checkbox list item (anywhere
+on the item) and use <leader>x to toggle the checkbox state.
 
-There are also |bullets-commands| that you can use to to create your own mappings.
+Vimwiki-style checkboxes allow for marking a checkbox as partially complete
+based on how many of its child checkboxes are checked. Partially complete
+checkboxes can use different markers to indicate a relative percentage of
+completion. Vimwiki-style (partial completion) checkboxes can be disabled
+through the `g:bullets_checkbox_markers` configuration option (see
+|bullets-configuration|).
+
+There are also |bullets-commands| that you can use to to create your own
+mappings.
 
 
 MAPPINGS                                    *bullets-mappings*
@@ -213,18 +332,48 @@ INSERT MODE
                                             *bullets-i_<C-cr>*
 <C-CR>      Same as <CR>, in case you want to unmap <CR> in INSERT MODE.
 
+                                            *bullets-i_<C-d>*
+<C-D>       Promotes the current bullet item by unindenting the line and
+            changing the bullet to the previous type defined in
+            g:bullets_outline_levels.
+
+                                            *bullets-i_<C-t>*
+<C-T>       Demotes the current bullet item by indenting the line and changing
+            the bullet to the next type defined in g:bullets_outline_levels.
+
 NORMAL MODE
 
                                             *bullets-o*
 o           Inserts a new bullet list item. Same as <CR> in INSERT MODE.
 
+                                            *bullets-gN*
+gN          Renumbers entire list containing the current cursor position.
+
                                             *bullets-<leader>x*
 <leader>x   Toggles the checkbox on the current line.
+
+                                            *bullets->>*
+>>          Promotes the current bullet item by unindenting the line and
+            changing the bullet to the next type defined in
+            g:bullets_outline_levels.
+
+                                            *bullets-<<*
+<<          Demotes the current bullet item by indenting the line and changing
+            the bullet to the previous type defined in g:bullets_outline_levels.
 
 VISUAL MODE
 
                                             *bullets-v_gN*
 gN          Renumbers selected bullet list items.
 
+                                            *bullets-v_>*
+>           Promotes the currently selected bullet item(s) by unindenting the
+            lines and changing the bullets to the next type defined in
+            g:bullets_outline_levels.
+
+                                            *bullets-v_<*
+<           Demotes the currently selected bullet item(s) by indenting the
+            lines and changing the bullets to the previous type defined in
+            g:bullets_outline_levels.
 
 vim:tw=78:et:ft=help:norl:

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -421,7 +421,8 @@ fun! s:next_num_bullet(bullet)
 endfun
 
 fun! s:next_chk_bullet(bullet)
-  return '- [ ]'
+  let l:checkbox_markers = split(g:bullets_checkbox_markers, '\zs')
+  return '- [' . l:checkbox_markers[0] . ']'
 endfun
 " }}}
 

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -331,12 +331,12 @@ fun! s:resolve_rom_or_abc(bullet_types)
     let l:bullet_indent = indent(l:first_type.starting_at_line_num)
     let l:prev_bullet_types = s:closest_bullet_types(l:prev_search_starting_line, l:bullet_indent)
 
-    while l:prev_bullet_types != [] && l:bullet_indent > indent(l:prev_search_starting_line)
+    while l:prev_bullet_types != [] && l:bullet_indent <= indent(l:prev_search_starting_line)
       let l:prev_search_starting_line -= g:bullets_line_spacing
       let l:prev_bullet_types = s:closest_bullet_types(l:prev_search_starting_line, l:bullet_indent)
     endwhile
 
-    if len(l:prev_bullet_types) == 0
+    if len(l:prev_bullet_types) == 0 || l:bullet_indent > indent(l:prev_search_starting_line)
 
       " can't find previous bullet - so we probably have a rom i. bullet
       return s:find_by_type(a:bullet_types, 'rom')
@@ -719,7 +719,8 @@ fun! s:renumber_selection()
 
     if !empty(l:bullet) && l:bullet.starting_at_line_num == l:line.nr
       " skip wrapped lines and lines that aren't bullets
-      if l:indent > l:prev_indent || !has_key(l:levels, l:indent)
+      if (l:indent > l:prev_indent || !has_key(l:levels, l:indent))
+          \ && l:bullet.bullet_type !=# 'chk' && l:bullet.bullet_type !=# 'std'
         if !has_key(l:levels, l:indent)
           let l:levels[l:indent] = {'index': 1}
         endif
@@ -731,14 +732,11 @@ fun! s:renumber_selection()
         let l:levels[l:indent].type = l:bullet.bullet_type
         let l:levels[l:indent].bullet = l:bullet.bullet " for standard bullets
         let l:levels[l:indent].closure = l:bullet.closure " normalize closures
-
-        " use the first bullet as the first padding length, and store it for
-        " each indent level
-        " 10. firstline  -> 1.  firstline
-        " 1.  secondline -> 2.  secondline
-        let l:levels[l:indent].pad_len = l:bullet.bullet_length
+        let l:levels[l:indent].trailing_space = l:bullet.trailing_space
       else
-        let l:levels[l:indent].index += 1
+        if l:bullet.bullet_type !=# 'chk' && l:bullet.bullet_type !=# 'std'
+          let l:levels[l:indent].index += 1
+        endif
 
         if l:indent < l:prev_indent
           " Reset the numbering on all all child items. Needed to avoid continuing
@@ -754,29 +752,29 @@ fun! s:renumber_selection()
 
       let l:prev_indent = l:indent
 
-      if l:levels[l:indent].type ==? 'rom'
-        let l:bullet_num = s:arabic2roman(l:levels[l:indent].index, l:levels[l:indent].islower)
-      elseif l:levels[l:indent].type ==? 'abc'
-        let l:bullet_num = s:dec2abc(l:levels[l:indent].index, l:levels[l:indent].islower)
-      elseif l:levels[l:indent].type ==# 'num'
-        let l:bullet_num = l:levels[l:indent].index
-      else
-        " normalize standard and checkbox bullets
-        let l:bullet_num = l:levels[l:indent].bullet
-      endif
+      if l:bullet.bullet_type !=# 'chk' && l:bullet.bullet_type !=# 'std'
+        if l:levels[l:indent].type ==? 'rom'
+          let l:bullet_num = s:arabic2roman(l:levels[l:indent].index, l:levels[l:indent].islower)
+        elseif l:levels[l:indent].type ==? 'abc'
+          let l:bullet_num = s:dec2abc(l:levels[l:indent].index, l:levels[l:indent].islower)
+        elseif l:levels[l:indent].type ==# 'num'
+          let l:bullet_num = l:levels[l:indent].index
+        endif
 
-      let l:new_bullet =
-            \ l:bullet.leading_space
-            \ . l:bullet_num
-            \ . l:levels[l:indent].closure
-            \ . (l:levels[l:indent].pad_len == 0 ? l:bullet.trailing_space : ' ')
-      let l:new_bullet = s:pad_to_length(l:new_bullet, l:levels[l:indent].pad_len)
-      let l:levels[l:indent].pad_len = len(l:new_bullet)
-      let l:renumbered_line = l:new_bullet . l:bullet.text_after_bullet
-      call setline(l:line.nr, l:renumbered_line)
-
-      " Reset the checkbox marker if it already exists, or blank otherwise
-      if l:levels[l:indent].type ==# 'chk'
+        let l:new_bullet =
+              \ l:bullet_num
+              \ . l:levels[l:indent].closure
+              \ . l:levels[l:indent].trailing_space
+        if l:levels[l:indent].index > 1
+          let l:new_bullet = s:pad_to_length(l:new_bullet, l:levels[l:indent].pad_len)
+        endif
+        let l:levels[l:indent].pad_len = len(l:new_bullet)
+        let l:renumbered_line = l:bullet.leading_space
+              \ . l:new_bullet
+              \ . l:bullet.text_after_bullet
+        call setline(l:line.nr, l:renumbered_line)
+      elseif l:bullet.bullet_type ==# 'chk'
+        " Reset the checkbox marker if it already exists, or blank otherwise
         let l:marker = has_key(l:bullet, 'checkbox_marker') ?
               \ l:bullet.checkbox_marker : ' '
         call s:set_checkbox(l:line.nr, l:marker)

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -760,13 +760,9 @@ fun! s:renumber_selection()
         let l:bullet_num = s:dec2abc(l:levels[l:indent].index, l:levels[l:indent].islower)
       elseif l:levels[l:indent].type ==# 'num'
         let l:bullet_num = l:levels[l:indent].index
-      elseif l:levels[l:indent].type ==# 'std'
-        " normalize standard bullets
-        let l:bullet_num = l:levels[l:indent].bullet
       else
-        " checkboxes shouldn't change their checked status
-        " let l:bullet_num = l:bullet.bullet
-        break
+        " normalize standard and checkbox bullets
+        let l:bullet_num = l:levels[l:indent].bullet
       endif
 
       let l:new_bullet =
@@ -778,6 +774,13 @@ fun! s:renumber_selection()
       let l:levels[l:indent].pad_len = len(l:new_bullet)
       let l:renumbered_line = l:new_bullet . l:bullet.text_after_bullet
       call setline(l:line.nr, l:renumbered_line)
+
+      " Reset the checkbox marker if it already exists, or blank otherwise
+      if l:levels[l:indent].type ==# 'chk'
+        let l:marker = has_key(l:bullet, 'checkbox_marker') ?
+              \ l:bullet.checkbox_marker : ' '
+        call s:set_checkbox(l:line.nr, l:marker)
+      endif
     endif
   endfor
 endfun

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -11,10 +11,10 @@ set cpoptions&vim
 " -------------------------------------------------------  }}}
 
 " Prevent execution if already loaded ------------------   {{{
-" if exists('g:loaded_bullets_vim')
-"   finish
-" endif
-" let g:loaded_bullets_vim = 1
+if exists('g:loaded_bullets_vim')
+  finish
+endif
+let g:loaded_bullets_vim = 1
 " Prevent execution if already loaded ------------------   }}}
 
 " Read user configurable options -----------------------   {{{

--- a/spec/alphabetic_bullets_spec.rb
+++ b/spec/alphabetic_bullets_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe 'Bullets.vim' do
           G. seventh bullet
           H. eighth bullet
           I. ninth bullet
-          J. tenth bullet\n
+          J. tenth bullet
+
       TEXT
     end
 
@@ -92,7 +93,8 @@ RSpec.describe 'Bullets.vim' do
           g. seventh bullet
           h. eighth bullet
           i. ninth bullet
-          j. tenth bullet\n
+          j. tenth bullet
+
       TEXT
     end
 

--- a/spec/alphabetic_bullets_spec.rb
+++ b/spec/alphabetic_bullets_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe 'Bullets.vim' do
       TEXT
 
       vim.edit filename
+      vim.command('let g:bullets_renumber_on_change=0')
       vim.type 'GA'
       vim.feedkeys '\<cr>'
       vim.type 'second bullet'
@@ -184,6 +185,7 @@ RSpec.describe 'Bullets.vim' do
         TEXT
 
         vim.edit filename
+        vim.command('let g:bullets_renumber_on_change=0')
         vim.type 'GA'
         vim.feedkeys '\<cr>'
         vim.type 'second bullet'

--- a/spec/alphabetic_bullets_spec.rb
+++ b/spec/alphabetic_bullets_spec.rb
@@ -132,6 +132,49 @@ RSpec.describe 'Bullets.vim' do
       TEXT
     end
 
+    it 'does not add a new bullet when mixed case' do
+      test_bullet_inserted('not a bullet', <<-INIT, <<-EXPECTED)
+        # Hello there
+        Ab. this is the first bullet
+      INIT
+        # Hello there
+        Ab. this is the first bullet
+        not a bullet
+      EXPECTED
+    end
+
+    # it 'correctly numbers after wrapped lines starting with short words' do
+    # # TODO: maybe take guidance from Pandoc and require two spaces after the
+    # closure to allow us to differentiate between bullets and abbreviations
+    # and words. Might also consider only allowing single letters.
+    #   test_bullet_inserted('second bullet', <<-INIT, <<-EXPECTED)
+    #     # Hello there
+    #     a. first bullet might not catch
+    #        me. second line.
+    #   INIT
+    #     # Hello there
+    #     a. first bullet might not catch
+    #     \tme. second line.
+    #     b. second bullet
+    #   EXPECTED
+    # end
+
+    # it 'correctly numbers after lines beginning with initialized names' do
+    # # TODO: maybe take guidance from Pandoc and require two spaces after the
+    # closure to allow us to differentiate between bullets and abbreviations
+    # and words. Might also consider only allowing single letters.
+    #   test_bullet_inserted('Second bullet', <<-INIT, <<-EXPECTED)
+    #     # Hello there
+    #     I. The first president of the USA was
+    #        G. Washington.
+    #   INIT
+    #     # Hello there
+    #     I. The first president of the USA was
+    #        G. Washington.
+    #     II. Second bullet
+    #   EXPECTED
+    # end
+
     describe 'g:bullets_max_alpha_characters' do
       it 'stops adding items after configured max (default 2)' do
         filename = "#{SecureRandom.hex(6)}.txt"

--- a/spec/bullets_spec.rb
+++ b/spec/bullets_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe 'Bullets.vim' do
       end
 
       it 'maintains total bullet width from 9. to 10. with reduced padding' do
+        vim.command('let g:bullets_renumber_on_change=0')
         test_bullet_inserted('second bullet', <<-INIT, <<-EXPECTED)
           # Hello there
           9.  this is the first bullet

--- a/spec/checkboxes_spec.rb
+++ b/spec/checkboxes_spec.rb
@@ -24,4 +24,172 @@ RSpec.describe 'checkboxes' do
       - [ ] do that
     EXPECTED
   end
+
+  it 'toggle a bullet' do
+    filename = "#{SecureRandom.hex(6)}.txt"
+    write_file(filename, <<-TEXT)
+      # Hello there
+      - [ ] first bullet
+      - [X] second bullet
+      - [x] third bullet
+      - [.] fourth bullet
+      - [o] fifth bullet
+      - [O] sixth bullet
+    TEXT
+
+    vim.edit filename
+    vim.normal 'j'
+    vim.command 'ToggleCheckbox'
+    vim.normal 'j'
+    vim.command 'ToggleCheckbox'
+    vim.normal 'j'
+    vim.command 'ToggleCheckbox'
+    vim.normal 'j'
+    vim.command 'ToggleCheckbox'
+    vim.normal 'j'
+    vim.command 'ToggleCheckbox'
+    vim.normal 'j'
+    vim.command 'ToggleCheckbox'
+    vim.write
+
+    file_contents = IO.read(filename)
+
+    expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+      # Hello there
+      - [X] first bullet
+      - [ ] second bullet
+      - [ ] third bullet
+      - [X] fourth bullet
+      - [X] fifth bullet
+      - [X] sixth bullet
+
+    TEXT
+  end
+
+  it 'toggle a bullet and adjust parent' do
+    filename = "#{SecureRandom.hex(6)}.txt"
+    write_file(filename, <<-TEXT)
+      # Hello there
+      - [ ] first bullet
+        - [ ] second bullet
+          - [ ] third bullet
+    TEXT
+
+    vim.edit filename
+    vim.normal 'G'
+    vim.command 'ToggleCheckbox'
+    vim.write
+
+    file_contents = IO.read(filename)
+
+    expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+      # Hello there
+      - [X] first bullet
+        - [X] second bullet
+          - [X] third bullet
+
+    TEXT
+  end
+
+  it 'toggle a bullet and adjust children' do
+    filename = "#{SecureRandom.hex(6)}.txt"
+    write_file(filename, <<-TEXT)
+      # Hello there
+      - [ ] first bullet
+        - [ ] second bullet
+          - [ ] third bullet
+    TEXT
+
+    vim.edit filename
+    vim.normal 'j'
+    vim.command 'ToggleCheckbox'
+    vim.write
+
+    file_contents = IO.read(filename)
+
+    expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+      # Hello there
+      - [X] first bullet
+        - [X] second bullet
+          - [X] third bullet
+
+    TEXT
+  end
+
+  it 'toggle a bullet and calculate completion' do
+    filename = "#{SecureRandom.hex(6)}.txt"
+    write_file(filename, <<-TEXT)
+      # Hello there
+      - [ ] first bullet
+        - [ ] second bullet
+          - [ ] third bullet
+          - [ ] fourth bullet
+          - [ ] fifth bullet
+          - [ ] sixth bullet
+        - [ ] seventh bullet
+          - [ ] eighth bullet
+          - [ ] ninth bullet
+          - [ ] tenth bullet
+          - [ ] eleventh bullet
+        - [ ] twelfth bullet
+          - [ ] thirteenth bullet
+          - [ ] fourteenth bullet
+          - [ ] fifteenth bullet
+          - [ ] sixteenth bullet
+        - [X] seventeenth bullet
+          - [X] eighteenth bullet
+          - [X] ninteenth bullet
+          - [X] twentieth bullet
+          - [X] twenty-first bullet
+    TEXT
+
+    vim.edit filename
+    vim.normal '3j'
+    vim.command 'ToggleCheckbox'
+    vim.normal '6j'
+    vim.command 'ToggleCheckbox'
+    vim.normal 'j'
+    vim.command 'ToggleCheckbox'
+    vim.normal 'j'
+    vim.command 'ToggleCheckbox'
+    vim.normal '2j'
+    vim.command 'ToggleCheckbox'
+    vim.normal 'j'
+    vim.command 'ToggleCheckbox'
+    vim.normal 'j'
+    vim.command 'ToggleCheckbox'
+    vim.normal 'j'
+    vim.command 'ToggleCheckbox'
+    vim.normal '2j'
+    vim.command 'ToggleCheckbox'
+    vim.write
+
+    file_contents = IO.read(filename)
+
+    expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+      # Hello there
+      - [.] first bullet
+        - [.] second bullet
+          - [X] third bullet
+          - [ ] fourth bullet
+          - [ ] fifth bullet
+          - [ ] sixth bullet
+        - [O] seventh bullet
+          - [ ] eighth bullet
+          - [X] ninth bullet
+          - [X] tenth bullet
+          - [X] eleventh bullet
+        - [X] twelfth bullet
+          - [X] thirteenth bullet
+          - [X] fourteenth bullet
+          - [X] fifteenth bullet
+          - [X] sixteenth bullet
+        - [O] seventeenth bullet
+          - [ ] eighteenth bullet
+          - [X] ninteenth bullet
+          - [X] twentieth bullet
+          - [X] twenty-first bullet
+
+    TEXT
+  end
 end

--- a/spec/checkboxes_spec.rb
+++ b/spec/checkboxes_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe 'checkboxes' do
       # Hello there
       - [✓] first bullet
       - [◐] second bullet
-      \t- [ ] third bullet
+      \t- [✗] third bullet
       \t- [✓] fourth bullet
       - [✓] fifth bullet
       - [✗] sixth bullet

--- a/spec/checkboxes_spec.rb
+++ b/spec/checkboxes_spec.rb
@@ -192,4 +192,45 @@ RSpec.describe 'checkboxes' do
 
     TEXT
   end
+
+  it 'adds and toggles bullets using UTF characters' do
+    filename = "#{SecureRandom.hex(6)}.txt"
+    write_file(filename, <<-TEXT)
+      # Hello there
+      - [ ] first bullet
+    TEXT
+
+    vim.edit filename
+    vim.command 'let g:bullets_checkbox_markers="✗○◐●✓"'
+    vim.normal 'j'
+    vim.command 'ToggleCheckbox'
+    vim.feedkeys 'o'
+    vim.type 'second bullet'
+    vim.feedkeys '\<cr>\<C-t>'
+    vim.type 'third bullet'
+    vim.feedkeys '\<cr>'
+    vim.type 'fourth bullet<esc>'
+    vim.command 'ToggleCheckbox'
+    vim.feedkeys 'o\<C-d>'
+    vim.type 'fifth bullet<esc>'
+    vim.command 'ToggleCheckbox'
+    vim.feedkeys 'o'
+    vim.type 'sixth bullet'
+    vim.command 'ToggleCheckbox'
+    vim.command 'ToggleCheckbox'
+    vim.write
+
+    file_contents = IO.read(filename)
+
+    expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+      # Hello there
+      - [✓] first bullet
+      - [◐] second bullet
+      \t- [ ] third bullet
+      \t- [✓] fourth bullet
+      - [✓] fifth bullet
+      - [✗] sixth bullet
+
+    TEXT
+  end
 end

--- a/spec/nested_bullets_spec.rb
+++ b/spec/nested_bullets_spec.rb
@@ -124,25 +124,6 @@ RSpec.describe 'Bullets.vim' do
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-t>'
       vim.type 'second bullet'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-t>\<C-t>'
-      vim.type 'third bullet'
-      vim.feedkeys '\<esc>'
-      vim.feedkeys 'o'
-      vim.feedkeys '\<C-t>'
-      vim.type 'fourth bullet'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-t>'
-      vim.type 'fifth bullet'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-t>'
-      vim.type 'sixth bullet'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-t>'
-      vim.type 'seventh bullet'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-t>'
-      vim.type 'eighth bullet'
       vim.write
 
       file_contents = IO.read(filename)
@@ -151,12 +132,6 @@ RSpec.describe 'Bullets.vim' do
           # Hello there
           I. this is the first bullet
           \tA. second bullet
-          \t\t\t1. third bullet
-          \t\t\t\ta. fourth bullet
-          \t\t\t\t\ti. fifth bullet
-          \t\t\t\t\t\t- sixth bullet
-          \t\t\t\t\t\t\t* seventh bullet
-          \t\t\t\t\t\t\t\t+ eighth bullet
 
       TEXT
     end
@@ -167,29 +142,13 @@ RSpec.describe 'Bullets.vim' do
           # Hello there
           I. this is the first bullet
           \tA. second bullet
-          \t\t1. third bullet
-          \t\t\ta. fourth bullet
-          \t\t\t\ti. fifth bullet
-          \t\t\t\t\t- sixth bullet
       TEXT
 
       vim.edit filename
       vim.normal 'GA'
       vim.feedkeys '\<cr>'
-      vim.type 'seventh bullet'
-      vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-d>'
-      vim.type 'eighth bullet'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-d>'
-      vim.type 'ninth bullet'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-d>'
-      vim.type 'tenth bullet'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-d>'
-      vim.feedkeys '\<C-d>'
-      vim.type 'eleventh bullet'
+      vim.type 'third bullet'
       vim.write
 
       file_contents = IO.read(filename)
@@ -198,15 +157,7 @@ RSpec.describe 'Bullets.vim' do
           # Hello there
           I. this is the first bullet
           \tA. second bullet
-          \t\t1. third bullet
-          \t\t\ta. fourth bullet
-          \t\t\t\ti. fifth bullet
-          \t\t\t\t\t- sixth bullet
-          \t\t\t\t\t- seventh bullet
-          \t\t\t\tii. eighth bullet
-          \t\t\tb. ninth bullet
-          \t\t2. tenth bullet
-          II. eleventh bullet
+          II. third bullet
 
       TEXT
     end
@@ -217,7 +168,6 @@ RSpec.describe 'Bullets.vim' do
           # Hello there
           I. this is the first bullet
           \tA. second bullet
-          \t\t1. third bullet
       TEXT
 
       vim.edit filename
@@ -228,27 +178,6 @@ RSpec.describe 'Bullets.vim' do
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-t>'
       vim.type 'second bullet'
-      vim.feedkeys '\<cr>'
-      vim.type 'third bullet'
-      vim.feedkeys '\<C-t>'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<cr>'
-      vim.type '1. first bullet'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-t>'
-      vim.type 'second bullet'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-t>'
-      vim.type 'third bullet'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<cr>'
-      vim.type '- first bullet'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-t>'
-      vim.type 'second bullet'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-t>'
-      vim.type 'third bullet'
       vim.write
 
       file_contents = IO.read(filename)
@@ -257,19 +186,9 @@ RSpec.describe 'Bullets.vim' do
           # Hello there
           I. this is the first bullet
           \tA. second bullet
-          \t\t1. third bullet
 
           A. first bullet
           \t1. second bullet
-          \t\ta. third bullet
-
-          1. first bullet
-          \ta. second bullet
-          \t\ti. third bullet
-
-          - first bullet
-          \t* second bullet
-          \t\t+ third bullet
 
       TEXT
     end
@@ -338,44 +257,27 @@ RSpec.describe 'Bullets.vim' do
       write_file(filename, <<-TEXT)
           # Hello there
           1. this is the first bullet
-          2. second bullet
+          \ta. second bullet
       TEXT
 
       vim.edit filename
       vim.normal 'GA'
-      vim.feedkeys '\<C-t>'
+      vim.feedkeys '\<C-d>'
       vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
       vim.type 'third bullet'
-      vim.normal '3hi'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<cr>'
+      vim.type '+ fourth bullet'
+      vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-t>'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<esc>'
-      vim.feedkeys '>>'
-      vim.type 'astandard bullet'
-      vim.feedkeys '\<cr>'
-      vim.type 'fourth bullet'
-      vim.feedkeys '\<cr>'
       vim.type 'fifth bullet'
-      vim.feedkeys '\<C-d>'
-      vim.feedkeys '\<C-d>'
-      vim.feedkeys '\<esc>'
-      vim.feedkeys '<<'
-      vim.feedkeys 'i\<C-t>'
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<cr>'
-      vim.type '+ sixth bullet'
+      vim.type '* sixth bullet'
       vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-t>'
       vim.type 'seventh bullet'
-      vim.feedkeys '\<cr>'
-      vim.type 'eighth bullet'
-      vim.feedkeys '\<C-d>'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<cr>'
-      vim.type '* ninth bullet'
-      vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-t>'
-      vim.type 'tenth bullet'
 
       vim.write
 
@@ -384,23 +286,19 @@ RSpec.describe 'Bullets.vim' do
       expect(file_contents).to eq normalize_string_indent(<<-TEXT)
           # Hello there
           1. this is the first bullet
-          \ta. second bullet
-          \t\ti. third bullet
-          \t\t\t- standard bullet
-          \t\t\t- fourth bullet
-          \tb. fifth bullet
+          2. second bullet
+          \ta. third bullet
 
-          + sixth bullet
+          + fourth bullet
+          \t+ fifth bullet
+
+          * sixth bullet
           \t+ seventh bullet
-          + eighth bullet
-
-          * ninth bullet
-          \t+ tenth bullet
 
       TEXT
     end
 
-    it 'does not nest further below defined levels' do
+    it 'does not nest beyond defined levels' do
       filename = "#{SecureRandom.hex(6)}.txt"
       write_file(filename, <<-TEXT)
           # Hello there

--- a/spec/nested_bullets_spec.rb
+++ b/spec/nested_bullets_spec.rb
@@ -29,13 +29,17 @@ RSpec.describe 'Bullets.vim' do
       vim.normal 'j'
       vim.feedkeys '>>>>>>>>>>'
       vim.normal 'j'
-      vim.feedkeys '>>>>>>>>>>>>'
+      vim.feedkeys '>>>>>>>>'
+      vim.feedkeys '>>>>'
       vim.normal 'j'
-      vim.feedkeys '>>>>>>>>>>>>>>'
+      vim.feedkeys '>>>>>>>>'
+      vim.feedkeys '>>>>>>'
       vim.normal 'j'
-      vim.feedkeys '>>>>>>>>>>>>>>>>'
+      vim.feedkeys '>>>>>>>>'
+      vim.feedkeys '>>>>>>>>'
       vim.normal 'j'
-      vim.feedkeys '>>>>>>>>>>>>>>>>>>'
+      vim.feedkeys '>>>>>>>>'
+      vim.feedkeys '>>>>>>>>>>'
       vim.write
 
       file_contents = IO.read(filename)
@@ -50,7 +54,7 @@ RSpec.describe 'Bullets.vim' do
           \t\t\t\t\t\t- sixth bullet
           \t\t\t\t\t\t\t* seventh bullet
           \t\t\t\t\t\t\t\t+ eighth bullet
-          \t\t\t\t\t\t\t\t\tninth bullet
+          \t\t\t\t\t\t\t\t\t+ ninth bullet
 
       TEXT
     end
@@ -78,13 +82,18 @@ RSpec.describe 'Bullets.vim' do
       vim.normal 'j'
       vim.feedkeys '<<<<<<'
       vim.normal 'j'
-      vim.feedkeys '<<<<<<<<<<'
+      vim.feedkeys '<<<<<<'
+      vim.feedkeys '<<<<'
       vim.normal 'j'
-      vim.feedkeys '<<<<<<<<<<<<'
+      vim.feedkeys '<<<<<<'
+      vim.feedkeys '<<<<<<'
       vim.normal 'j'
-      vim.feedkeys '<<<<<<<<<<<<<<'
+      vim.feedkeys '<<<<<<'
+      vim.feedkeys '<<<<<<<<'
       vim.normal 'j'
-      vim.feedkeys '<<<<<<<<<<<<<<<<'
+      vim.feedkeys '<<<<<<'
+      vim.feedkeys '<<<<<<'
+      vim.feedkeys '<<<<'
       vim.write
 
       file_contents = IO.read(filename)
@@ -290,17 +299,18 @@ RSpec.describe 'Bullets.vim' do
       vim.type 'sixth bullet'
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-t>'
-      vim.type 'not a bullet'
-      vim.feedkeys '\<cr>'
       vim.type 'seventh bullet'
       vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-d>'
       vim.type 'eighth bullet'
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-d>'
+      vim.feedkeys '\<C-d>'
       vim.type 'ninth bullet'
       vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-d>'
       vim.type 'tenth bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'eleventh bullet'
 
       vim.write
 
@@ -314,11 +324,11 @@ RSpec.describe 'Bullets.vim' do
           \tB. fourth bullet
           \t\t* fifth bullet
           \t\t* sixth bullet
-          \t\t\tnot a bullet
-          \t\t* seventh bullet
-          \tC. eighth bullet
-          3. ninth bullet
-          4. tenth bullet
+          \t\t\t* seventh bullet
+          \t\t\t* eighth bullet
+          \tC. ninth bullet
+          3. tenth bullet
+          4. eleventh bullet
 
       TEXT
     end
@@ -356,15 +366,16 @@ RSpec.describe 'Bullets.vim' do
       vim.type '+ sixth bullet'
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-t>'
-      vim.type 'not a bullet'
-      vim.feedkeys '\<cr>'
       vim.type 'seventh bullet'
       vim.feedkeys '\<cr>'
+      vim.type 'eighth bullet'
+      vim.feedkeys '\<C-d>'
       vim.feedkeys '\<cr>'
-      vim.type '* eighth bullet'
+      vim.feedkeys '\<cr>'
+      vim.type '* ninth bullet'
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-t>'
-      vim.type 'ninth bullet'
+      vim.type 'tenth bullet'
 
       vim.write
 
@@ -380,16 +391,16 @@ RSpec.describe 'Bullets.vim' do
           \tb. fifth bullet
 
           + sixth bullet
-          \tnot a bullet
-          + seventh bullet
+          \t+ seventh bullet
+          + eighth bullet
 
-          * eighth bullet
-          \t+ ninth bullet
+          * ninth bullet
+          \t+ tenth bullet
 
       TEXT
     end
 
-    it 'does not nest below defined levels' do
+    it 'does not nest further below defined levels' do
       filename = "#{SecureRandom.hex(6)}.txt"
       write_file(filename, <<-TEXT)
           # Hello there
@@ -408,9 +419,9 @@ RSpec.describe 'Bullets.vim' do
       vim.normal 'GA'
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-t>'
-      vim.type 'not a bullet'
-      vim.feedkeys '\<cr>'
       vim.type 'tenth bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'eleventh bullet'
       vim.write
 
       file_contents = IO.read(filename)
@@ -426,8 +437,8 @@ RSpec.describe 'Bullets.vim' do
           \t\t\t\t\t- seventh bullet
           \t\t\t\t\t\t* eighth bullet
           \t\t\t\t\t\t\t+ ninth bullet
-          \t\t\t\t\t\t\t\tnot a bullet
-          \t\t\t\t\t\t\t+ tenth bullet
+          \t\t\t\t\t\t\t\t+ tenth bullet
+          \t\t\t\t\t\t\t\t+ eleventh bullet
 
       TEXT
     end
@@ -596,6 +607,70 @@ RSpec.describe 'Bullets.vim' do
           \t\t\t\twrapped line
 
           \t\t\td. eighteenth bullet
+
+      TEXT
+    end
+
+    it 'changes levels in visual mode' do
+      filename = "#{SecureRandom.hex(6)}.txt"
+      write_file(filename, <<-TEXT)
+          # Hello there
+          1. first bullet
+          \ta. second bullet
+          \tb. third bullet
+          \t\t* fourth bullet
+          \t\t* fifth bullet
+          \t\t\tsixth bullet
+          \t\t* seventh bullet
+          2. eighth bullet
+          \t\ta. ninth bullet
+          \ta. tenth bullet
+          \tb. eleventh bullet
+          3. twelfth bullet
+          \t thirteenth bullet
+          \ta. fourteenth bullet
+          \t\t* fifteenth bullet
+          4. sixteenth bullet
+      TEXT
+
+      vim.edit filename
+      vim.command "let g:bullets_outline_levels=['num','abc','std*']"
+      vim.normal '3jv'
+      vim.feedkeys '<'
+      vim.normal 'jv2j'
+      vim.feedkeys '<'
+      vim.normal 'jvj'
+      vim.feedkeys '>'
+      vim.normal 'jvj'
+      vim.feedkeys '<'
+      vim.feedkeys '<'
+      vim.normal 'jv'
+      vim.feedkeys '>'
+      vim.normal '3jv2j'
+      vim.feedkeys '>'
+      vim.feedkeys '>'
+      vim.write
+
+      file_contents = IO.read(filename)
+
+      expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+          # Hello there
+          1. first bullet
+          \ta. second bullet
+          2. third bullet
+          \ta. fourth bullet
+          \tb. fifth bullet
+          \t\tsixth bullet
+          \t\t\t* seventh bullet
+          \tc. eighth bullet
+          3. ninth bullet
+          tenth bullet
+          \t\ta. eleventh bullet
+          4. twelfth bullet
+          \t thirteenth bullet
+          \t\t\ta. fourteenth bullet
+          \t\t\t\t* fifteenth bullet
+          \t\ta. sixteenth bullet
 
       TEXT
     end

--- a/spec/nested_bullets_spec.rb
+++ b/spec/nested_bullets_spec.rb
@@ -1,0 +1,641 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Bullets.vim' do
+  describe 'nested bullets' do
+    it 'demotes an existing bullet' do
+      filename = "#{SecureRandom.hex(6)}.txt"
+      write_file(filename, <<-TEXT)
+          # Hello there
+          I. this is the first bullet
+          II. second bullet
+          III. third bullet
+          IV. fourth bullet
+          V. fifth bullet
+          VI. sixth bullet
+          VII. seventh bullet
+          VIII. eighth bullet
+          IX. ninth bullet
+      TEXT
+
+      vim.edit filename
+      vim.normal '2ji'
+      vim.feedkeys '\<C-t>'
+      vim.normal 'j'
+      vim.feedkeys '>>>>>>'
+      vim.normal 'j'
+      vim.feedkeys '>>>>>>>>'
+      vim.normal 'j'
+      vim.feedkeys '>>>>>>>>>>'
+      vim.normal 'j'
+      vim.feedkeys '>>>>>>>>>>>>'
+      vim.normal 'j'
+      vim.feedkeys '>>>>>>>>>>>>>>'
+      vim.normal 'j'
+      vim.feedkeys '>>>>>>>>>>>>>>>>'
+      vim.normal 'j'
+      vim.feedkeys '>>>>>>>>>>>>>>>>>>'
+      vim.write
+
+      file_contents = IO.read(filename)
+
+      expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+          # Hello there
+          I. this is the first bullet
+          \tA. second bullet
+          \t\t\t1. third bullet
+          \t\t\t\ta. fourth bullet
+          \t\t\t\t\ti. fifth bullet
+          \t\t\t\t\t\t- sixth bullet
+          \t\t\t\t\t\t\t* seventh bullet
+          \t\t\t\t\t\t\t\t+ eighth bullet
+          \t\t\t\t\t\t\t\t\tninth bullet
+
+      TEXT
+    end
+
+    it 'promotes an existing bullet' do
+      filename = "#{SecureRandom.hex(6)}.txt"
+      write_file(filename, <<-TEXT)
+          # Hello there
+          I. this is the first bullet
+          \tA. second bullet
+          \t\t\t1. third bullet
+          \t\t\t\ta. fourth bullet
+          \t\t\t\t\ti. fifth bullet
+          \t\t\t\t\t\t- sixth bullet
+          \t\t\t\t\t\t\t* seventh bullet
+          \t\t\t\t\t\t\t\t+ eighth bullet
+      TEXT
+
+      vim.edit filename
+      vim.normal '2j'
+      vim.feedkeys '<<'
+      vim.normal 'ji'
+      vim.feedkeys '\<C-d>'
+      vim.feedkeys '\<C-d>'
+      vim.normal 'j'
+      vim.feedkeys '<<<<<<'
+      vim.normal 'j'
+      vim.feedkeys '<<<<<<<<<<'
+      vim.normal 'j'
+      vim.feedkeys '<<<<<<<<<<<<'
+      vim.normal 'j'
+      vim.feedkeys '<<<<<<<<<<<<<<'
+      vim.normal 'j'
+      vim.feedkeys '<<<<<<<<<<<<<<<<'
+      vim.write
+
+      file_contents = IO.read(filename)
+
+      expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+          # Hello there
+          I. this is the first bullet
+          II. second bullet
+          \tA. third bullet
+          \tB. fourth bullet
+          III. fifth bullet
+          IV.  sixth bullet
+          V.   seventh bullet
+          VI.  eighth bullet
+
+      TEXT
+    end
+
+    it 'demotes an empty bullet' do
+      filename = "#{SecureRandom.hex(6)}.txt"
+      write_file(filename, <<-TEXT)
+          # Hello there
+          I. this is the first bullet
+      TEXT
+
+      vim.edit filename
+      vim.normal 'GA'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'second bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>\<C-t>'
+      vim.type 'third bullet'
+      vim.feedkeys '\<esc>'
+      vim.feedkeys 'o'
+      vim.feedkeys '\<C-t>'
+      vim.type 'fourth bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'fifth bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'sixth bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'seventh bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'eighth bullet'
+      vim.write
+
+      file_contents = IO.read(filename)
+
+      expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+          # Hello there
+          I. this is the first bullet
+          \tA. second bullet
+          \t\t\t1. third bullet
+          \t\t\t\ta. fourth bullet
+          \t\t\t\t\ti. fifth bullet
+          \t\t\t\t\t\t- sixth bullet
+          \t\t\t\t\t\t\t* seventh bullet
+          \t\t\t\t\t\t\t\t+ eighth bullet
+
+      TEXT
+    end
+
+    it 'promotes an empty bullet' do
+      filename = "#{SecureRandom.hex(6)}.txt"
+      write_file(filename, <<-TEXT)
+          # Hello there
+          I. this is the first bullet
+          \tA. second bullet
+          \t\t1. third bullet
+          \t\t\ta. fourth bullet
+          \t\t\t\ti. fifth bullet
+          \t\t\t\t\t- sixth bullet
+      TEXT
+
+      vim.edit filename
+      vim.normal 'GA'
+      vim.feedkeys '\<cr>'
+      vim.type 'seventh bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-d>'
+      vim.type 'eighth bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-d>'
+      vim.type 'ninth bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-d>'
+      vim.type 'tenth bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-d>'
+      vim.feedkeys '\<C-d>'
+      vim.type 'eleventh bullet'
+      vim.write
+
+      file_contents = IO.read(filename)
+
+      expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+          # Hello there
+          I. this is the first bullet
+          \tA. second bullet
+          \t\t1. third bullet
+          \t\t\ta. fourth bullet
+          \t\t\t\ti. fifth bullet
+          \t\t\t\t\t- sixth bullet
+          \t\t\t\t\t- seventh bullet
+          \t\t\t\tii. eighth bullet
+          \t\t\tb. ninth bullet
+          \t\t2. tenth bullet
+          II. eleventh bullet
+
+      TEXT
+    end
+
+    it 'restarts numbering with multiple outlines' do
+      filename = "#{SecureRandom.hex(6)}.txt"
+      write_file(filename, <<-TEXT)
+          # Hello there
+          I. this is the first bullet
+          \tA. second bullet
+          \t\t1. third bullet
+      TEXT
+
+      vim.edit filename
+      vim.normal 'GA'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<cr>'
+      vim.type 'A. first bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'second bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'third bullet'
+      vim.feedkeys '\<C-t>'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<cr>'
+      vim.type '1. first bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'second bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'third bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<cr>'
+      vim.type '- first bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'second bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'third bullet'
+      vim.write
+
+      file_contents = IO.read(filename)
+
+      expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+          # Hello there
+          I. this is the first bullet
+          \tA. second bullet
+          \t\t1. third bullet
+
+          A. first bullet
+          \t1. second bullet
+          \t\ta. third bullet
+
+          1. first bullet
+          \ta. second bullet
+          \t\ti. third bullet
+
+          - first bullet
+          \t* second bullet
+          \t\t+ third bullet
+
+      TEXT
+    end
+
+    it 'works with custom outline level definitions' do
+      filename = "#{SecureRandom.hex(6)}.txt"
+      write_file(filename, <<-TEXT)
+          # Hello there
+      TEXT
+
+      vim.edit filename
+      vim.command "let g:bullets_outline_levels=['num','ABC','std*']"
+      vim.normal 'GA'
+      vim.feedkeys '\<cr>'
+      vim.type '1. first bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'second bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'third bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'fourth bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'fifth bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'sixth bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'not a bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'seventh bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-d>'
+      vim.type 'eighth bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-d>'
+      vim.type 'ninth bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'tenth bullet'
+
+      vim.write
+
+      file_contents = IO.read(filename)
+
+      expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+          # Hello there
+          1. first bullet
+          2. second bullet
+          \tA. third bullet
+          \tB. fourth bullet
+          \t\t* fifth bullet
+          \t\t* sixth bullet
+          \t\t\tnot a bullet
+          \t\t* seventh bullet
+          \tC. eighth bullet
+          3. ninth bullet
+          4. tenth bullet
+
+      TEXT
+    end
+
+    it 'promotes and demotes from different starting levels' do
+      filename = "#{SecureRandom.hex(6)}.txt"
+      write_file(filename, <<-TEXT)
+          # Hello there
+          1. this is the first bullet
+          2. second bullet
+      TEXT
+
+      vim.edit filename
+      vim.normal 'GA'
+      vim.feedkeys '\<C-t>'
+      vim.feedkeys '\<cr>'
+      vim.type 'third bullet'
+      vim.normal '3hi'
+      vim.feedkeys '\<C-t>'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<esc>'
+      vim.feedkeys '>>'
+      vim.type 'astandard bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'fourth bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'fifth bullet'
+      vim.feedkeys '\<C-d>'
+      vim.feedkeys '\<C-d>'
+      vim.feedkeys '\<esc>'
+      vim.feedkeys '<<'
+      vim.feedkeys 'i\<C-t>'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<cr>'
+      vim.type '+ sixth bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'not a bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'seventh bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<cr>'
+      vim.type '* eighth bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'ninth bullet'
+
+      vim.write
+
+      file_contents = IO.read(filename)
+
+      expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+          # Hello there
+          1. this is the first bullet
+          \ta. second bullet
+          \t\ti. third bullet
+          \t\t\t- standard bullet
+          \t\t\t- fourth bullet
+          \tb. fifth bullet
+
+          + sixth bullet
+          \tnot a bullet
+          + seventh bullet
+
+          * eighth bullet
+          \t+ ninth bullet
+
+      TEXT
+    end
+
+    it 'does not nest below defined levels' do
+      filename = "#{SecureRandom.hex(6)}.txt"
+      write_file(filename, <<-TEXT)
+          # Hello there
+          I. this is the first bullet
+          \tA. second bullet
+          \t\t1. third bullet
+          \t\t\ta. fourth bullet
+          \t\t\t\ti. fifth bullet
+          \t\t\t\tii. sixth bullet
+          \t\t\t\t\t- seventh bullet
+          \t\t\t\t\t\t* eighth bullet
+          \t\t\t\t\t\t\t+ ninth bullet
+      TEXT
+
+      vim.edit filename
+      vim.normal 'GA'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'not a bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'tenth bullet'
+      vim.write
+
+      file_contents = IO.read(filename)
+
+      expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+          # Hello there
+          I. this is the first bullet
+          \tA. second bullet
+          \t\t1. third bullet
+          \t\t\ta. fourth bullet
+          \t\t\t\ti. fifth bullet
+          \t\t\t\tii. sixth bullet
+          \t\t\t\t\t- seventh bullet
+          \t\t\t\t\t\t* eighth bullet
+          \t\t\t\t\t\t\t+ ninth bullet
+          \t\t\t\t\t\t\t\tnot a bullet
+          \t\t\t\t\t\t\t+ tenth bullet
+
+      TEXT
+    end
+
+    it 'removes bullet when promoting top level bullet' do
+      filename = "#{SecureRandom.hex(6)}.txt"
+      write_file(filename, <<-TEXT)
+          # Hello there
+          A. this is the first bullet
+
+          I. second bullet
+          \tA. third bullet
+      TEXT
+
+      vim.edit filename
+      vim.normal 'j'
+      vim.feedkeys '<<'
+      vim.normal '3ji'
+      vim.feedkeys '\<C-d>'
+      vim.feedkeys '\<C-d>'
+      vim.write
+
+      file_contents = IO.read(filename)
+
+      expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+          # Hello there
+          this is the first bullet
+
+          I. second bullet
+          third bullet
+
+      TEXT
+    end
+
+    it 'handle standard bullets when they are not in outline list' do
+      filename = "#{SecureRandom.hex(6)}.txt"
+      write_file(filename, <<-TEXT)
+          # Hello there
+          1. this is the first bullet
+          \t- standard bullet
+      TEXT
+
+      vim.edit filename
+      vim.command "let g:bullets_outline_levels=['num','ABC']"
+      vim.normal 'GA'
+      vim.feedkeys '\<cr>'
+      vim.type 'second standard bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-d>'
+      vim.type 'second bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'third bullet'
+      vim.write
+
+      file_contents = IO.read(filename)
+
+      expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+          # Hello there
+          1. this is the first bullet
+          \t- standard bullet
+          \t- second standard bullet
+          2. second bullet
+          3. third bullet
+
+      TEXT
+    end
+
+    it 'adds new nested bullets with correct alpha/roman numerals' do
+      filename = "#{SecureRandom.hex(6)}.txt"
+      write_file(filename, <<-TEXT)
+          # Hello there
+          I. this is the first bullet
+
+          \tA. second bullet
+
+          \tB. third bullet
+
+          \tC. fourth bullet
+      TEXT
+
+      vim.edit filename
+      vim.command 'let g:bullets_line_spacing=2'
+      vim.normal 'GA'
+      vim.feedkeys '\<cr>'
+      vim.type 'fifth bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-d>'
+      vim.type 'sixth bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'seventh bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'eighth bullet'
+      vim.feedkeys '\<C-t>'
+      vim.feedkeys '\<cr>'
+      vim.type 'ninth bullet'
+      vim.feedkeys '\<C-t>'
+      vim.feedkeys '\<cr>'
+      vim.type 'tenth bullet'
+      vim.feedkeys '\<C-t>'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'eleventh bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'twelfth bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'thirteenth bullet'
+      vim.feedkeys '\<C-t>'
+      vim.feedkeys '\<cr>'
+      vim.type 'fourteenth bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'fifteenth bullet'
+      vim.feedkeys '\<C-d>'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-d>'
+      vim.type 'sixteenth bullet'
+      vim.feedkeys '\<cr>'
+      vim.normal 'dd'
+      vim.insert '				wrapped line'
+      vim.feedkeys '\<cr>'
+      vim.type 'seventeenth bullet'
+      vim.feedkeys '\<cr>'
+      vim.normal 'dd'
+      vim.insert '				wrapped line'
+      vim.feedkeys '\<cr>'
+      vim.type 'eighteenth bullet'
+      vim.write
+
+      file_contents = IO.read(filename)
+
+      expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+          # Hello there
+          I. this is the first bullet
+
+          \tA. second bullet
+
+          \tB. third bullet
+
+          \tC. fourth bullet
+
+          \tD. fifth bullet
+
+          II. sixth bullet
+
+          III. seventh bullet
+
+          \tA. eighth bullet
+
+          \t\t1. ninth bullet
+
+          \t\t\ta. tenth bullet
+
+          \t\t\t\ti. eleventh bullet
+
+          \t\t\t\tii. twelfth bullet
+
+          \t\t\t\t\t- thirteenth bullet
+
+          \t\t\t\t\t- fourteenth bullet
+
+          \t\t\t\tiii. fifteenth bullet
+
+          \t\t\tb. sixteenth bullet
+          \t\t\t\twrapped line
+
+          \t\t\tc. seventeenth bullet
+          \t\t\t\twrapped line
+
+          \t\t\td. eighteenth bullet
+
+      TEXT
+    end
+
+    it 'add and change bullets with multiple line spacing and wrapped lines' do
+      filename = "#{SecureRandom.hex(6)}.txt"
+      write_file(filename, <<-TEXT)
+          # Hello there
+          I. this is the first bullet
+      TEXT
+
+      vim.edit filename
+      vim.command 'let g:bullets_line_spacing=2'
+      vim.normal 'GA'
+      vim.feedkeys '\<cr>'
+      vim.type 'second bullet'
+      vim.feedkeys '\<cr>'
+      vim.feedkeys '\<C-t>'
+      vim.type 'third bullet'
+      vim.feedkeys '\<cr>'
+      vim.normal 'dd'
+      vim.insert '	wrapped bullet'
+      vim.feedkeys '\<cr>'
+      vim.type 'fourth bullet'
+      vim.write
+
+      file_contents = IO.read(filename)
+
+      expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+          # Hello there
+          I. this is the first bullet
+
+          II. second bullet
+
+          \tA. third bullet
+          \twrapped bullet
+
+          \tB. fourth bullet
+
+      TEXT
+    end
+  end
+end

--- a/spec/nested_bullets_spec.rb
+++ b/spec/nested_bullets_spec.rb
@@ -511,59 +511,40 @@ RSpec.describe 'Bullets.vim' do
       write_file(filename, <<-TEXT)
           # Hello there
           I. this is the first bullet
-
           \tA. second bullet
-
-          \tB. third bullet
-
-          \tC. fourth bullet
       TEXT
 
       vim.edit filename
-      vim.command 'let g:bullets_line_spacing=2'
       vim.normal 'GA'
       vim.feedkeys '\<cr>'
-      vim.type 'fifth bullet'
+      vim.type 'third bullet'
+      vim.feedkeys '\<C-t>'
       vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-d>'
+      vim.type 'fourth bullet'
+      vim.feedkeys '\<C-t>'
+      vim.feedkeys '\<cr>'
+      vim.type 'fifth bullet'
+      vim.feedkeys '\<C-t>'
+      vim.feedkeys '\<cr>'
       vim.type 'sixth bullet'
+      vim.feedkeys '\<C-t>'
       vim.feedkeys '\<cr>'
       vim.type 'seventh bullet'
       vim.feedkeys '\<cr>'
       vim.type 'eighth bullet'
-      vim.feedkeys '\<C-t>'
+      vim.feedkeys '\<C-d>'
       vim.feedkeys '\<cr>'
       vim.type 'ninth bullet'
-      vim.feedkeys '\<C-t>'
+      vim.feedkeys '\<C-d>'
       vim.feedkeys '\<cr>'
       vim.type 'tenth bullet'
-      vim.feedkeys '\<C-t>'
+      vim.feedkeys '\<C-d>'
       vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-t>'
       vim.type 'eleventh bullet'
+      vim.feedkeys '\<C-d>'
       vim.feedkeys '\<cr>'
       vim.type 'twelfth bullet'
-      vim.feedkeys '\<cr>'
-      vim.type 'thirteenth bullet'
-      vim.feedkeys '\<C-t>'
-      vim.feedkeys '\<cr>'
-      vim.type 'fourteenth bullet'
-      vim.feedkeys '\<cr>'
-      vim.type 'fifteenth bullet'
       vim.feedkeys '\<C-d>'
-      vim.feedkeys '\<cr>'
-      vim.feedkeys '\<C-d>'
-      vim.type 'sixteenth bullet'
-      vim.feedkeys '\<cr>'
-      vim.normal 'dd'
-      vim.insert '				wrapped line'
-      vim.feedkeys '\<cr>'
-      vim.type 'seventeenth bullet'
-      vim.feedkeys '\<cr>'
-      vim.normal 'dd'
-      vim.insert '				wrapped line'
-      vim.feedkeys '\<cr>'
-      vim.type 'eighteenth bullet'
       vim.write
 
       file_contents = IO.read(filename)
@@ -571,42 +552,17 @@ RSpec.describe 'Bullets.vim' do
       expect(file_contents).to eq normalize_string_indent(<<-TEXT)
           # Hello there
           I. this is the first bullet
-
           \tA. second bullet
-
-          \tB. third bullet
-
-          \tC. fourth bullet
-
-          \tD. fifth bullet
-
-          II. sixth bullet
-
-          III. seventh bullet
-
-          \tA. eighth bullet
-
-          \t\t1. ninth bullet
-
-          \t\t\ta. tenth bullet
-
-          \t\t\t\ti. eleventh bullet
-
-          \t\t\t\tii. twelfth bullet
-
-          \t\t\t\t\t- thirteenth bullet
-
-          \t\t\t\t\t- fourteenth bullet
-
-          \t\t\t\tiii. fifteenth bullet
-
-          \t\t\tb. sixteenth bullet
-          \t\t\t\twrapped line
-
-          \t\t\tc. seventeenth bullet
-          \t\t\t\twrapped line
-
-          \t\t\td. eighteenth bullet
+          \t\t1. third bullet
+          \t\t\ta. fourth bullet
+          \t\t\t\ti. fifth bullet
+          \t\t\t\t\t- sixth bullet
+          \t\t\t\t\t- seventh bullet
+          \t\t\t\tii. eighth bullet
+          \t\t\tb. ninth bullet
+          \t\t2. tenth bullet
+          \tB. eleventh bullet
+          II. twelfth bullet
 
       TEXT
     end

--- a/spec/renumber_bullets_spec.rb
+++ b/spec/renumber_bullets_spec.rb
@@ -28,4 +28,253 @@ RSpec.describe 're-numbering' do
       4.  this is the fourth bullet\n
     TEXT
   end
+
+  it 'visually renumbers a nested list' do
+    filename = "#{SecureRandom.hex(6)}.txt"
+    write_file(filename, <<-TEXT)
+      # Hello there
+      0. zero bullet
+
+      X. first bullet
+
+      - second bullet
+      \twrapped line
+
+      a. third bullet
+
+      I. fourth bullet
+
+      \tV. fifth bullet
+
+      \t\tB. sixth bullet
+
+      \t* seventh bullet
+
+      \t\ti. eighth bullet
+
+      \t\tx. ninth bullet
+      \t\t\t wrapped line
+
+      \t\t\ta. tenth bullet
+      wrapped line without indent
+
+      \tC. eleventh bullet
+      \t\t0. twelfth bullet
+
+      \t\t\t* thirteenth bullet
+
+      \t\t\t\t+ fourteenth bullet
+
+      \t\t\td. fifteenth bullet
+
+      \t\ta. sixteenth bullet
+
+      \t\t\t8. seventeenth bullet
+
+      \t\t\t0. eighteenth bullet
+      \t\t\t\t wrapped line
+
+      \tnormal indented line
+      next normal line
+
+      1. nineteenth bullet
+      x. twentieth bullet
+
+      v. twenty-first bullet
+      - twenty-second bullet
+
+
+      v. twenty-third bullet
+    TEXT
+
+    vim.edit filename
+    vim.command 'let g:bullets_line_spacing=2'
+    vim.normal '3jVG19k'
+    vim.feedkeys 'gN'
+    vim.normal 'GV6k'
+    vim.feedkeys 'gN'
+    vim.write
+
+    file_contents = IO.read(filename)
+
+    expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+      # Hello there
+      0. zero bullet
+
+      I. first bullet
+
+      II. second bullet
+      \twrapped line
+
+      III. third bullet
+
+      IV.  fourth bullet
+
+      \tI. fifth bullet
+
+      \t\tA. sixth bullet
+
+      \tII. seventh bullet
+
+      \t\ta. eighth bullet
+
+      \t\tb. ninth bullet
+      \t\t\t wrapped line
+
+      \t\t\ta. tenth bullet
+      wrapped line without indent
+
+      \tIII. eleventh bullet
+      \t\t1. twelfth bullet
+
+      \t\t\t* thirteenth bullet
+
+      \t\t\t\t+ fourteenth bullet
+
+      \t\t\t* fifteenth bullet
+
+      \t\ta. sixteenth bullet
+
+      \t\t\t8. seventeenth bullet
+
+      \t\t\t0. eighteenth bullet
+      \t\t\t\t wrapped line
+
+      \tnormal indented line
+      next normal line
+
+      1. nineteenth bullet
+      i. twentieth bullet
+
+      ii. twenty-first bullet
+      iii. twenty-second bullet
+
+
+      iv.  twenty-third bullet
+
+    TEXT
+  end
+
+  it 'renumbers a nested list' do
+    filename = "#{SecureRandom.hex(6)}.txt"
+    write_file(filename, <<-TEXT)
+      # Hello there
+      0. zero bullet
+
+      X. first bullet
+
+      - second bullet
+      \twrapped line
+
+      a. third bullet
+
+      I. fourth bullet
+
+      \tV. fifth bullet
+
+      \t\tB. sixth bullet
+
+      \t* seventh bullet
+
+      \t\ti. eighth bullet
+
+      \t\tx. ninth bullet
+      \t\t\t wrapped line
+
+      \t\t\ta. tenth bullet
+      wrapped line without indent
+
+      \tC. eleventh bullet
+      \t\t0. twelfth bullet
+
+      \t\t\t* thirteenth bullet
+
+      \t\t\t\t+ fourteenth bullet
+
+      \t\t\td. fifteenth bullet
+
+      \t\ta. sixteenth bullet
+
+      \t\t\t8. seventeenth bullet
+
+      \t\t\t0. eighteenth bullet
+      \t\t\t\t wrapped line
+
+      \tnormal indented line
+      next normal line
+
+      1. nineteenth bullet
+      x. twentieth bullet
+
+      v. twenty-first bullet
+      - twenty-second bullet
+
+
+      v. twenty-third bullet
+    TEXT
+
+    vim.edit filename
+    vim.type '2jVGk'
+    vim.feedkeys 'gN'
+    vim.write
+
+    file_contents = IO.read(filename)
+
+    expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+      # Hello there
+      0. zero bullet
+
+      I. first bullet
+
+      II. second bullet
+      \twrapped line
+
+      III. third bullet
+
+      IV.  fourth bullet
+
+      \tI. fifth bullet
+
+      \t\tA. sixth bullet
+
+      \tII. seventh bullet
+
+      \t\ti. eighth bullet
+
+      \t\tii. ninth bullet
+      \t\t\t wrapped line
+
+      \t\t\ta. tenth bullet
+      wrapped line without indent
+
+      \tIII. eleventh bullet
+      \t\t1. twelfth bullet
+
+      \t\t\t* thirteenth bullet
+
+      \t\t\t\t+ fourteenth bullet
+
+      \t\t\t* fifteenth bullet
+
+      \t\t2. sixteenth bullet
+
+      \t\t\t1. seventeenth bullet
+
+      \t\t\t2. eighteenth bullet
+      \t\t\t\t wrapped line
+
+      \tnormal indented line
+      next normal line
+
+      V.   nineteenth bullet
+      VI.  twentieth bullet
+
+      VII. twenty-first bullet
+      VIII. twenty-second bullet
+
+
+      v. twenty-third bullet
+
+    TEXT
+  end
 end

--- a/spec/renumber_bullets_spec.rb
+++ b/spec/renumber_bullets_spec.rb
@@ -29,6 +29,44 @@ RSpec.describe 're-numbering' do
     TEXT
   end
 
+  it 'renumbers a list containing checkboxes' do
+    filename = "#{SecureRandom.hex(6)}.txt"
+    write_file(filename, <<-TEXT)
+      # Hello there
+      33. this is the first bullet
+      - [x] this is the second bullet
+      1.     this is the third bullet
+        - [ ] this is the fourth bullet
+      4. this is the fifth bullet
+
+      - [o] second bullet list
+      a. second item
+      - [x] third item
+    TEXT
+
+    vim.edit filename
+    vim.type 'j'
+    vim.feedkeys 'gN'
+    vim.type '}j'
+    vim.feedkeys 'gN'
+    vim.write
+
+    file_contents = IO.read(filename)
+
+    expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+      # Hello there
+      1.  this is the first bullet
+      2.  this is the second bullet
+      3.  this is the third bullet
+        - [ ] this is the fourth bullet
+      4.  this is the fifth bullet
+
+      - [o] second bullet list
+      - [ ] second item
+      - [x] third item\n
+    TEXT
+  end
+
   it 'visually renumbers a nested list' do
     filename = "#{SecureRandom.hex(6)}.txt"
     write_file(filename, <<-TEXT)

--- a/spec/renumber_bullets_spec.rb
+++ b/spec/renumber_bullets_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe 're-numbering' do
 
     expect(file_contents).to eq normalize_string_indent(<<-TEXT)
       # Hello there
-      1.  this is the first bullet
-      2.  this is the second bullet
-      3.  this is the third bullet
-      4.  this is the fourth bullet\n
+      1. this is the first bullet
+      2. this is the second bullet
+      3. this is the third bullet
+      4. this is the fourth bullet\n
     TEXT
   end
 
@@ -40,7 +40,7 @@ RSpec.describe 're-numbering' do
       4. this is the fifth bullet
 
       - [o] second bullet list
-      a. second item
+      b. second item
       - [x] third item
     TEXT
 
@@ -55,15 +55,145 @@ RSpec.describe 're-numbering' do
 
     expect(file_contents).to eq normalize_string_indent(<<-TEXT)
       # Hello there
-      1.  this is the first bullet
-      2.  this is the second bullet
-      3.  this is the third bullet
+      1. this is the first bullet
+      - [x] this is the second bullet
+      2. this is the third bullet
         - [ ] this is the fourth bullet
-      4.  this is the fifth bullet
+      3. this is the fifth bullet
 
       - [o] second bullet list
-      - [ ] second item
+      a. second item
       - [x] third item\n
+    TEXT
+  end
+
+  it 'renumbers a nested list' do
+    filename = "#{SecureRandom.hex(6)}.txt"
+    write_file(filename, <<-TEXT)
+      # Hello there
+      0. zero bullet
+
+      X. first bullet
+
+      - second bullet
+      \twrapped line
+
+      a. third bullet
+
+      I. fourth bullet
+
+      \tV. fifth bullet
+
+      \t\tB. sixth bullet
+
+      \t* seventh bullet
+
+      \t\ti. eighth bullet
+
+      \t\tx. ninth bullet
+      \t\t\t wrapped line
+
+      \t\t\ta. tenth bullet
+      wrapped line without indent
+
+      \tC. eleventh bullet
+      \t\t0. twelfth bullet
+
+      \t\t\t* thirteenth bullet
+
+      \t\t\t\t+ fourteenth bullet
+
+      \t\t\tb. fifteenth bullet
+
+      \t\ta. sixteenth bullet
+
+      \t\t\t8. seventeenth bullet
+
+      \t\t\t0. eighteenth bullet
+      \t\t\t\t wrapped line
+
+      \tnormal indented line
+      next normal line
+
+      1. nineteenth bullet
+
+      x. twentieth bullet
+
+
+      v. twenty-first bullet
+      - twenty-second bullet
+
+
+      v. twenty-third bullet
+    TEXT
+
+    vim.edit filename
+    vim.command 'let g:bullets_line_spacing=2'
+    vim.normal '3j'
+    vim.feedkeys 'gN'
+    vim.normal 'G3k'
+    vim.feedkeys 'gN'
+    vim.write
+
+    file_contents = IO.read(filename)
+
+    expect(file_contents).to eq normalize_string_indent(<<-TEXT)
+      # Hello there
+      1. zero bullet
+
+      2. first bullet
+
+      - second bullet
+      \twrapped line
+
+      3. third bullet
+
+      4. fourth bullet
+
+      \tI. fifth bullet
+
+      \t\tA. sixth bullet
+
+      \t* seventh bullet
+
+      \t\ti. eighth bullet
+
+      \t\tii. ninth bullet
+      \t\t\t wrapped line
+
+      \t\t\ta. tenth bullet
+      wrapped line without indent
+
+      \tII. eleventh bullet
+      \t\t1. twelfth bullet
+
+      \t\t\t* thirteenth bullet
+
+      \t\t\t\t+ fourteenth bullet
+
+      \t\t\ta. fifteenth bullet
+
+      \t\t2. sixteenth bullet
+
+      \t\t\t1. seventeenth bullet
+
+      \t\t\t2. eighteenth bullet
+      \t\t\t\t wrapped line
+
+      \tnormal indented line
+      next normal line
+
+      1. nineteenth bullet
+
+      x. twentieth bullet
+
+
+      i. twenty-first bullet
+      - twenty-second bullet
+
+
+      v. twenty-third bullet
+
     TEXT
   end
 
@@ -116,7 +246,9 @@ RSpec.describe 're-numbering' do
       next normal line
 
       1. nineteenth bullet
+
       x. twentieth bullet
+
 
       v. twenty-first bullet
       - twenty-second bullet
@@ -127,131 +259,6 @@ RSpec.describe 're-numbering' do
 
     vim.edit filename
     vim.command 'let g:bullets_line_spacing=2'
-    vim.normal '3jVG19k'
-    vim.feedkeys 'gN'
-    vim.normal 'GV6k'
-    vim.feedkeys 'gN'
-    vim.write
-
-    file_contents = IO.read(filename)
-
-    expect(file_contents).to eq normalize_string_indent(<<-TEXT)
-      # Hello there
-      0. zero bullet
-
-      I. first bullet
-
-      II. second bullet
-      \twrapped line
-
-      III. third bullet
-
-      IV.  fourth bullet
-
-      \tI. fifth bullet
-
-      \t\tA. sixth bullet
-
-      \tII. seventh bullet
-
-      \t\ta. eighth bullet
-
-      \t\tb. ninth bullet
-      \t\t\t wrapped line
-
-      \t\t\ta. tenth bullet
-      wrapped line without indent
-
-      \tIII. eleventh bullet
-      \t\t1. twelfth bullet
-
-      \t\t\t* thirteenth bullet
-
-      \t\t\t\t+ fourteenth bullet
-
-      \t\t\t* fifteenth bullet
-
-      \t\ta. sixteenth bullet
-
-      \t\t\t8. seventeenth bullet
-
-      \t\t\t0. eighteenth bullet
-      \t\t\t\t wrapped line
-
-      \tnormal indented line
-      next normal line
-
-      1. nineteenth bullet
-      i. twentieth bullet
-
-      ii. twenty-first bullet
-      iii. twenty-second bullet
-
-
-      iv.  twenty-third bullet
-
-    TEXT
-  end
-
-  it 'renumbers a nested list' do
-    filename = "#{SecureRandom.hex(6)}.txt"
-    write_file(filename, <<-TEXT)
-      # Hello there
-      0. zero bullet
-
-      X. first bullet
-
-      - second bullet
-      \twrapped line
-
-      a. third bullet
-
-      I. fourth bullet
-
-      \tV. fifth bullet
-
-      \t\tB. sixth bullet
-
-      \t* seventh bullet
-
-      \t\ti. eighth bullet
-
-      \t\tx. ninth bullet
-      \t\t\t wrapped line
-
-      \t\t\ta. tenth bullet
-      wrapped line without indent
-
-      \tC. eleventh bullet
-      \t\t0. twelfth bullet
-
-      \t\t\t* thirteenth bullet
-
-      \t\t\t\t+ fourteenth bullet
-
-      \t\t\td. fifteenth bullet
-
-      \t\ta. sixteenth bullet
-
-      \t\t\t8. seventeenth bullet
-
-      \t\t\t0. eighteenth bullet
-      \t\t\t\t wrapped line
-
-      \tnormal indented line
-      next normal line
-
-      1. nineteenth bullet
-      x. twentieth bullet
-
-      v. twenty-first bullet
-      - twenty-second bullet
-
-
-      v. twenty-third bullet
-    TEXT
-
-    vim.edit filename
     vim.type '2jVGk'
     vim.feedkeys 'gN'
     vim.write
@@ -264,18 +271,18 @@ RSpec.describe 're-numbering' do
 
       I. first bullet
 
-      II. second bullet
+      - second bullet
       \twrapped line
 
-      III. third bullet
+      II. third bullet
 
-      IV.  fourth bullet
+      III. fourth bullet
 
       \tI. fifth bullet
 
       \t\tA. sixth bullet
 
-      \tII. seventh bullet
+      \t* seventh bullet
 
       \t\ti. eighth bullet
 
@@ -285,14 +292,14 @@ RSpec.describe 're-numbering' do
       \t\t\ta. tenth bullet
       wrapped line without indent
 
-      \tIII. eleventh bullet
+      \tII. eleventh bullet
       \t\t1. twelfth bullet
 
       \t\t\t* thirteenth bullet
 
       \t\t\t\t+ fourteenth bullet
 
-      \t\t\t* fifteenth bullet
+      \t\t\ti. fifteenth bullet
 
       \t\t2. sixteenth bullet
 
@@ -304,11 +311,13 @@ RSpec.describe 're-numbering' do
       \tnormal indented line
       next normal line
 
-      V.   nineteenth bullet
-      VI.  twentieth bullet
+      IV.  nineteenth bullet
 
-      VII. twenty-first bullet
-      VIII. twenty-second bullet
+      V.   twentieth bullet
+
+
+      VI.  twenty-first bullet
+      - twenty-second bullet
 
 
       v. twenty-third bullet


### PR DESCRIPTION
This addresses #61. It is enabled by default, but perhaps it would be better to disable it by default since it is not standard GFM markdown syntax.

Note: this also fixes a bug in parsing checkboxes and renumbering lists containing checkbox bullets