### PR TITLE
Do not use normal mode to replace / insert text

### DIFF
--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -1243,8 +1243,8 @@ endfun
 
 fun! s:replace_char_in_line(lnum, chari, item)
   let l:curline = getline(a:lnum)
-  let l:before = strgetchar(l:curline, chari - 1)
-  let l:after = strgetchar(l:curline, chari + 1)
+  let l:before = strcharpart(l:curline, 0, a:chari)
+  let l:after = strcharpart(l:curline, a:chari + 1)
   call setline(a:lnum, l:before . a:item . l:after)
 endfun
 

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -558,10 +558,8 @@ endfun
 fun! s:set_checkbox(lnum, marker)
   let l:initpos = getpos('.')
   let l:pos = s:find_checkbox_position(a:lnum)
-  let l:checkbox_content = getline(a:lnum)[l:pos]
   " select inside checkbox
-  call setpos('.', [0, a:lnum, l:pos])
-  execute 'normal! ci[' . a:marker
+  call s:replace(a:lnum, l:pos, a:marker)
   call setpos('.', l:initpos)
 endfun
 
@@ -1242,6 +1240,16 @@ fun! s:sibling_checkbox_status(lnum)
   let l:divisions = len(l:checkbox_markers) - 1.0
   let l:completion = float2nr(ceil(l:divisions * l:checked / l:num_siblings))
   return l:checkbox_markers[l:completion]
+endfun
+
+fun! s:replace_char(lnum, col, item)
+    call s:replace(a:lnum, a:col - 1, a:col + 1, a:item)
+endfun
+
+fun! s:replace(lnum, col_start, col_end, item)
+  let l:curline = getline(a:lnum)
+  let l:newline = l:curline[0: a:col_start] . a:item . l:curline[a:col_end: -1]
+  call setline(a:lnum, l:newline)
 endfun
 
 " ------------------------------------------------------- }}}

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -559,7 +559,7 @@ fun! s:set_checkbox(lnum, marker)
   let l:initpos = getpos('.')
   let l:pos = s:find_checkbox_position(a:lnum)
   " select inside checkbox
-  call s:replace(a:lnum, l:pos, a:marker)
+  call s:replace_char(a:lnum, l:pos, a:marker)
   call setpos('.', l:initpos)
 endfun
 

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -558,7 +558,6 @@ endfun
 fun! s:set_checkbox(lnum, marker)
   let l:initpos = getpos('.')
   let l:pos = s:find_checkbox_position(a:lnum)
-  " select inside checkbox
   call s:replace_char_in_line(a:lnum, l:pos, a:marker)
   call setpos('.', l:initpos)
 endfun
@@ -1242,14 +1241,11 @@ fun! s:sibling_checkbox_status(lnum)
   return l:checkbox_markers[l:completion]
 endfun
 
-fun! s:replace_char_in_line(lnum, col, item)
-    call s:replace_in_line(a:lnum, a:col - 1, a:col + 1, a:item)
-endfun
-
-fun! s:replace_in_line(lnum, col_start, col_end, item)
+fun! s:replace_char_in_line(lnum, chari, item)
   let l:curline = getline(a:lnum)
-  let l:newline = l:curline[0: a:col_start] . a:item . l:curline[a:col_end: -1]
-  call setline(a:lnum, l:newline)
+  let l:before = strgetchar(l:curline, chari - 1)
+  let l:after = strgetchar(l:curline, chari + 1)
+  call setline(a:lnum, l:before . a:item . l:after)
 endfun
 
 " ------------------------------------------------------- }}}

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -559,7 +559,7 @@ fun! s:set_checkbox(lnum, marker)
   let l:initpos = getpos('.')
   let l:pos = s:find_checkbox_position(a:lnum)
   " select inside checkbox
-  call s:replace_char(a:lnum, l:pos, a:marker)
+  call s:replace_char_in_line(a:lnum, l:pos, a:marker)
   call setpos('.', l:initpos)
 endfun
 
@@ -1242,11 +1242,11 @@ fun! s:sibling_checkbox_status(lnum)
   return l:checkbox_markers[l:completion]
 endfun
 
-fun! s:replace_char(lnum, col, item)
-    call s:replace(a:lnum, a:col - 1, a:col + 1, a:item)
+fun! s:replace_char_in_line(lnum, col, item)
+    call s:replace_in_line(a:lnum, a:col - 1, a:col + 1, a:item)
 endfun
 
-fun! s:replace(lnum, col_start, col_end, item)
+fun! s:replace_in_line(lnum, col_start, col_end, item)
   let l:curline = getline(a:lnum)
   let l:newline = l:curline[0: a:col_start] . a:item . l:curline[a:col_end: -1]
   call setline(a:lnum, l:newline)


### PR DESCRIPTION
Using normal mode commands to insert characters is very slow on my laptop (I am running WSL on windows).

In this PR, I have replaced normal-mode functionality with vim functions, which are faster.

This PR is still a work in progress. I am creating it as a place-holder and so that I can get feedback.