### PR TITLE
Do not add extra newline when deleting a blank bullet

### DIFF
--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -430,7 +430,9 @@ endfun
 fun! s:delete_empty_bullet(line_num)
   if g:bullets_delete_last_bullet_if_empty
     call setline(a:line_num, '')
+    return 1
   endif
+  return 0
 endfun
 
 fun! s:insert_new_bullet()
@@ -443,6 +445,7 @@ fun! s:insert_new_bullet()
   " searching up from there
   let l:send_return = 1
   let l:normal_mode = mode() ==# 'n'
+  let l:deleted_empty_bullet = 0
 
   " check if current line is a bullet and we are at the end of the line (for
   " insert mode only)
@@ -451,7 +454,7 @@ fun! s:insert_new_bullet()
     if l:bullet.text_after_bullet ==# ''
       " We don't want to create a new bullet if the previous one was not used,
       " instead we want to delete the empty bullet - like word processors do
-      call s:delete_empty_bullet(l:curr_line_num)
+      let l:deleted_empty_bullet = s:delete_empty_bullet(l:curr_line_num)
     elseif !(l:bullet.bullet_type ==# 'abc' && s:abc2dec(l:bullet.bullet) + 1 > s:abc_max)
 
       let l:next_bullet = s:next_bullet_str(l:bullet)
@@ -479,7 +482,7 @@ fun! s:insert_new_bullet()
     endif
   endif
 
-  if l:send_return || l:normal_mode
+  if (l:send_return || l:normal_mode) && !l:deleted_empty_bullet
     " start a new line
     if l:normal_mode
       startinsert!

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -482,14 +482,16 @@ fun! s:insert_new_bullet()
     endif
   endif
 
-  if (l:send_return || l:normal_mode) && !l:deleted_empty_bullet
+  if l:send_return || l:normal_mode
     " start a new line
     if l:normal_mode
       startinsert!
     endif
 
-    let l:keys = l:send_return ? "\<CR>" : ''
-    call feedkeys(l:keys, 'n')
+    if !l:deleted_empty_bullet
+      let l:keys = l:send_return ? "\<CR>" : ''
+      call feedkeys(l:keys, 'n')
+    endif
   endif
 
   " need to return a string since we are in insert mode calling with <C-R>=

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -488,9 +488,8 @@ fun! s:insert_new_bullet()
       startinsert!
     endif
 
-    if !l:deleted_empty_bullet
-      let l:keys = l:send_return ? "\<CR>" : ''
-      call feedkeys(l:keys, 'n')
+    if l:send_return && !l:deleted_empty_bullet
+      call feedkeys("\<CR>", 'n')
     endif
   endif
 

--- a/spec/alphabetic_bullets_spec.rb
+++ b/spec/alphabetic_bullets_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe 'Bullets.vim' do
       vim.type 'third bullet'
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<cr>'
+      vim.feedkeys '\<cr>'
       vim.type 'AY. fourth bullet'
       vim.feedkeys '\<cr>'
       vim.type 'fifth bullet'

--- a/spec/nested_bullets_spec.rb
+++ b/spec/nested_bullets_spec.rb
@@ -176,6 +176,7 @@ RSpec.describe 'Bullets.vim' do
       vim.feedkeys '\<cr>'
       vim.type 'A. first bullet'
       vim.feedkeys '\<cr>'
+      vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-t>'
       vim.type 'second bullet'
       vim.write
@@ -266,6 +267,7 @@ RSpec.describe 'Bullets.vim' do
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<C-t>'
       vim.type 'third bullet'
+      vim.feedkeys '\<cr>'
       vim.feedkeys '\<cr>'
       vim.feedkeys '\<cr>'
       vim.type '+ fourth bullet'


### PR DESCRIPTION
Currently, if there is no text after the current bullet, and I enter a newline (`<cr>`), the bullet is deleted and a newline is entered. This leaves a blank line after the current list.

In this PR, I have changed is behavior to not insert a new line. This new behavior matches other text editors and document processors.