### PR TITLE
fix: next checkbox bullet type

### DIFF
--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -422,7 +422,7 @@ endfun
 
 fun! s:next_chk_bullet(bullet)
   let l:checkbox_markers = split(g:bullets_checkbox_markers, '\zs')
-  return '- [' . l:checkbox_markers[0] . ']'
+  return a:bullet.bullet[0].' [' . l:checkbox_markers[0] . ']'
 endfun
 " }}}
 


### PR DESCRIPTION
**_what_**: This pull request allows for automatic insertion of checkbox bullet types `- [ ]` _and_ `* [ ]`.

**_why_**: From what I can tell, bullets.vim will match either `- [ ]` or `* [ ]` syntax as checkbox bullets (seen in the `match_checkbox_bullet_item()` function). However, when it comes to automatically inserting a new bullet in a list of checkboxes, the `next_chk_bullet()` function only inserts new checkboxes with `- [ ]` syntax, regardless of the style matched in the list.

**_how_**: The proposed change is a one line fix, inserting the first character of the matched checkbox bullet found in `match_checkbox_bullet_item()` as the first character of the next bullet. This enables either of the matched syntax styles to be automatically extended (which seems like the expected behavior).

**_testing_**: I've had this change made in my local vim setup for the last few days, and things seem to be working as expected. This is by no means comprehensive testing, but the nature of the fix leads me to believe the scope of possible consequences in quite small to begin with. Please let me know if there any issues or standards I've overlooked here.