### PR TITLE
Add support for setting custom mappings

### DIFF
--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -509,6 +509,7 @@ endfun
 command! InsertNewBullet call <SID>insert_new_bullet()
 
 inoremap <silent> <Plug>(bullets-insert-new-bullet) <C-]><C-R>=<SID>insert_new_bullet()<cr>
+nnoremap <silent> <Plug>(bullets-insert-new-bullet-normal) :call <SID>insert_new_bullet()<cr>
 
 " --------------------------------------------------------- }}}
 
@@ -1006,7 +1007,7 @@ augroup TextBulletsMappings
     call s:add_local_mapping('imap', '<cr>', '<Plug>(bullets-insert-new-bullet)')
     call s:add_local_mapping('inoremap', '<C-cr>', '<cr>')
 
-    call s:add_local_mapping('nnoremap', 'o', ':call <SID>insert_new_bullet()<cr>')
+    call s:add_local_mapping('nmap', 'o', '<Plug>(bullets-insert-new-bullet-normal)')
 
     " Renumber bullet list
     call s:add_local_mapping('vnoremap', 'gN', ':RenumberSelection<cr>')

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -507,6 +507,9 @@ fun! s:is_at_eol()
 endfun
 
 command! InsertNewBullet call <SID>insert_new_bullet()
+
+inoremap <silent> <Plug>(bullets-insert-new-bullet) <C-]><C-R>=<SID>insert_new_bullet()<cr>
+
 " --------------------------------------------------------- }}}
 
 " Checkboxes ---------------------------------------------- {{{
@@ -1000,7 +1003,7 @@ augroup TextBulletsMappings
 
   if g:bullets_set_mappings
     " automatic bullets
-    call s:add_local_mapping('inoremap', '<cr>', '<C-]><C-R>=<SID>insert_new_bullet()<cr>')
+    call s:add_local_mapping('imap', '<cr>', '<Plug>(bullets-insert-new-bullet)')
     call s:add_local_mapping('inoremap', '<C-cr>', '<cr>')
 
     call s:add_local_mapping('nnoremap', 'o', ':call <SID>insert_new_bullet()<cr>')

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -100,6 +100,11 @@ endif
 
 " Parse Bullet Type -------------------------------------------  {{{
 fun! s:parse_bullet(line_num, line_text)
+  let l:kinds = s:match_all_items(a:line_text)
+  return s:map(l:kinds, 'extend(v:val, { "starting_at_line_num": ' . a:line_num . ' })')
+endfun
+
+fun! s:match_all_items(line_text)
   let l:kinds = s:filter(
         \ [
         \  s:match_bullet_list_item(a:line_text),
@@ -111,7 +116,7 @@ fun! s:parse_bullet(line_num, line_text)
         \ '!empty(v:val)'
         \ )
 
-  return s:map(l:kinds, 'extend(v:val, { "starting_at_line_num": ' . a:line_num . ' })')
+  return l:kinds
 endfun
 
 fun! s:match_numeric_list_item(input_text)

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -119,6 +119,10 @@ fun! s:match_all_items(line_text)
   return l:kinds
 endfun
 
+fun! bullets#is_part_of_a_bullet_list()
+  return s:match_all_items(getline('.')) != []
+endfun
+
 fun! s:match_numeric_list_item(input_text)
   let l:num_bullet_regex  = '\v^((\s*)(\d+)(\.|\))(\s+))(.*)'
   let l:matches           = matchlist(a:input_text, l:num_bullet_regex)


### PR DESCRIPTION
This PR implements the functionnality to set custom mappings.
This option can be used by setting the `g:bullets_bindings` variable in the vim rc file as follow (for example):

```
let g:bullets_bindings = [
    \['inoremap', '<cr>', '<C-o>:InsertNewBullet<cr>'],
    \['nnoremap', 'o', ':InsertNewBullet<cr>'],
    \['nnoremap', '<C-t>', ':ToggleCheckbox<cr>'],
\]
```
Note that the `ToggleCheckbox` is binded to `Ctrl-T` in this case for example.
This allows to set only a part of the bindinds, as the users whiches.

Moreover, the doc is not set at the moment but should be done before merging if this feature is OK for you.