### PR TITLE
Add doc/tags to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+doc/tags
 vendor/
 spec/examples.txt


### PR DESCRIPTION
Thanks for a great plugin!

If this is installed in a personal dotfiles repository, using the new vim plugin installation method, as a git submodule (example with `homesick`):

```sh
cd ~/.homesick/repos/dotfiles
mkdir -p home/.vim/pack/bundle/start
cd home/.vim/pack/bundle/start
git submodule add https://... bullets.vim
```

And then you run `helptags ALL`, the file `doc/tags` will be generated inside the submodule, and appear as "(untracked content)" in the `git status` for the dotfiles repository as a whole.

Simplest fix ever: add `doc/tags` to the `.gitignore` file, and the problem goes away!