### PR TITLE
Add Sagemath prompts as std bullets

### DIFF
--- a/doc/bullets.txt
+++ b/doc/bullets.txt
@@ -36,6 +36,7 @@ B) or this style of alphabetic
 i. Roman numeral lists
 II. or capitalized Roman numeral lists
 \item latex item lists
+sage: Sagemath command line items
 **** Org mode headers
 
 It supports nested (heirarchical) ordered lists/outlines using different types
@@ -85,13 +86,13 @@ GENERAL COMMANDS                            *bullets-commands*
 
                                             *bullets-:BulletDemote*
 :BulletDemote          Demotes the current bullet by indenting it and changing
-                       its bullet type to the next level defined in 
+                       its bullet type to the next level defined in
                        g:bullets_outline_levels. Mapped to <C-t> in INSERT
                        mode and `>>` in NORMAL mode.
 
                                             *bullets-:BulletPromote*
-:BulletPromote         Promotes the current bullet by unindenting it and 
-                       changing its bullet type to the next level defined in 
+:BulletPromote         Promotes the current bullet by unindenting it and
+                       changing its bullet type to the next level defined in
                        g:bullets_outline_levels. Mapped to <C-d> in INSERT
                        mode and `<<` in NORMAL mode by default.
 

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -248,7 +248,7 @@ fun! s:match_checkbox_bullet_item(input_text)
 endfun
 
 fun! s:match_bullet_list_item(input_text)
-  let l:std_bullet_regex  = '\v(^(\s*)(-|\*+|\.+|#\.|\+|\\item)(\s+))(.*)'
+  let l:std_bullet_regex  = '\v(^(\s*)(-|\*+|\.+|#\.|\+|sage:|\\item)(\s+))(.*)'
   let l:matches           = matchlist(a:input_text, l:std_bullet_regex)
 
   if empty(l:matches)

--- a/spec/bullets_spec.rb
+++ b/spec/bullets_spec.rb
@@ -40,6 +40,23 @@ RSpec.describe 'Bullets.vim' do
         EXPECTED
       end
 
+      it 'adds a new Sagemath bullet' do
+        test_bullet_inserted('Second item', <<-INIT, <<-EXPECTED)
+        \\documentclass{article}
+          \\begin{document}
+
+          \\begin{sagecommandline}
+          sage: item
+        INIT
+        \\documentclass{article}
+          \\begin{document}
+
+          \\begin{sagecommandline}
+          sage: item
+          sage: Second item
+        EXPECTED
+      end
+
       it 'adds a new latex bullet' do
         test_bullet_inserted('Second item', <<-INIT, <<-EXPECTED)
         \\documentclass{article}


### PR DESCRIPTION
Sagetex allows latex users to run sagemath commands inside a LaTeX document for
computational maths. It's environment looks like this:

```
\begin{sagecommandline}
sage: f(x) = 2*pi*x/e**x
sage: g(x) = f.ingegrate(x)
sage: plot(g(x), -5, 5)
\end{sagecommandline}
```

You can see how it behaves just like a bullet. This is why I suggest that this
be added to bullets.vim.
