### PR TITLE
Make bullet list item styles configurable

### DIFF
--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -57,6 +57,12 @@ while s:power >= 0
   let s:power -= 1
 endwhile
 
+if !exists('g:bullets_list_item_styles')
+  " A list of regex patterns that are recognized as bullet points for
+  " bullet items.
+  let g:bullets_list_item_styles = ['-', '\*+', '\.+', '#\.', '\+', '\\item']
+endif
+
 if !exists('g:bullets_outline_levels')
   " Capitalization matters: all caps will make the symbol caps, lower = lower
   " Standard bullets should include the marker symbol after 'std'
@@ -248,7 +254,9 @@ fun! s:match_checkbox_bullet_item(input_text)
 endfun
 
 fun! s:match_bullet_list_item(input_text)
-  let l:std_bullet_regex  = '\v(^(\s*)(-|\*+|\.+|#\.|\+|\\item)(\s+))(.*)'
+  let l:std_bullet_regex  = '\v(^(\s*)('
+        \ . join(g:bullets_list_item_styles, '|')
+        \ . ')(\s+))(.*)'
   let l:matches           = matchlist(a:input_text, l:std_bullet_regex)
 
   if empty(l:matches)


### PR DESCRIPTION
This commit introduces a new option `g:bullets_list_item_styles` to specify a list of regexes that match valid bullet point characters to be recognized by bullets.vim.

The default is the same as the currently hardcoded list.

This commit only introduces this configurability for bullet list items as this may be the most useful bullet item type to have configurability.

It may be considered to provide this configurability for the other bullet item types, too (like checkbox list items, etc.).

This change should probably fix #88 (but I am not sure as I don't really understand that issue)
and also render #98 and #106 obsolete, as such less common bullet items could easily be added by the user.

It would also offer the possibilty to query the list of bullet styles from other plugins (for example to provide syntax highlighting for them).

There is, however, one drawback (a drawback that is not introduced with this PR, but already exist in the current codebase). The list of valid bullet styles is totally separate from the list of bullet styles to be used for different indentation levels. This is not only surprising (as you can see in #112), but can also be error-prone (as it allows characters in `g:bullets_outline_levels` that are not valid bullet styles at all).
I think that can only be fixed by merging `g:bullets_list_item_styles` and `g:bullets_outline_levels` together into a single setting. That setting would probably be more complex and would maybe be a multi-dimensional list. But I have not put any thought into it. Just wanted to mention this problem that could be worth getting addressed.