### PR TITLE
Improve key mappings customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Bullets.vim](img/bullets-vim-logo.svg)
 
-[![Build Status](https://travis-ci.org/dkarter/bullets.vim.svg?branch=master)](https://travis-ci.org/dkarter/bullets.vim) 
+[![Build Status](https://travis-ci.org/dkarter/bullets.vim.svg?branch=master)](https://travis-ci.org/dkarter/bullets.vim)
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-15-orange.svg?style=flat-square)](#contributors-)
@@ -77,6 +77,32 @@ Add a leader key before default mappings:
 
 ```vim
 let g:bullets_mapping_leader = '<M-b>' " default = ''
+```
+
+Customize key mappings:
+
+```vim
+let g:bullets_set_mappings = 0 " disable adding default key mappings, default = 1
+
+" default = []
+let g:bullets_custom_mappings = [
+  \ ['imap', '<cr>', '<Plug>(bullets-newline)'],
+  \ ['inoremap', '<C-cr>', '<cr>'],
+  \
+  \ ['nmap', 'o', '<Plug>(bullets-newline)'],
+  \
+  \ ['vmap', 'gN', '<Plug>(bullets-renumber)'],
+  \ ['nmap', 'gN', '<Plug>(bullets-renumber)'],
+  \
+  \ ['nmap', '<leader>x', '<Plug>(bullets-toggle-checkbox)'],
+  \
+  \ ['imap', '<C-t>', '<Plug>(bullets-demote)'],
+  \ ['nmap', '>>', '<Plug>(bullets-demote)'],
+  \ ['vmap', '>', '<Plug>(bullets-demote)'],
+  \ ['imap', '<C-d>', '<Plug>(bullets-promote)'],
+  \ ['nmap', '<<', '<Plug>(bullets-promote)'],
+  \ ['vmap', '<', '<Plug>(bullets-promote)'],
+  \ ]
 ```
 
 Enable/disable deleting the last empty bullet when hitting `<cr>` (insert mode) or `o` (normal mode):
@@ -184,7 +210,7 @@ let g:bullets_nested_checkboxes = 1 " default = 1
 "   - [ ] child bullet  [ type <leader>x ]
 "     - [ ] sub-child
 "   - [ ] child bullet
-" 
+"
 " Result:
 " - [o] first bullet   [ <- indicates partial completion of sub-tasks ]
 "   - [X] child bullet
@@ -225,18 +251,18 @@ let g:bullets_checkbox_partials_toggle = 1 " default = 1
 " - [o] partially checked  [ type <leader>x ]
 "   - [x] sub bullet
 "   - [ ] sub bullet
-" 
+"
 " Result:
 " - [x] checked
 "   - [x] sub bullet
 "   - [x] sub bullet
-" 
+"
 " Example 2:
 let g:bullets_checkbox_partials_toggle = 0
 " - [o] partially checked  [ type <leader>x ]
 "   - [x] sub bullet
 "   - [ ] sub bullet
-" 
+"
 " Result:
 " - [ ] checked
 "   - [ ] sub bullet
@@ -269,7 +295,7 @@ let g:bullets_set_mappings = 0
 Add a leader key before default mappings:
 
 ```vim
-let g:bullets_mapping_leader = '<M-b>' 
+let g:bullets_mapping_leader = '<M-b>'
 " Set <M-b> to the leader before all default mappings:
 " Example: renumbering becomes `<M-b>gN` instead of just `gN`
 ```

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Customize key mappings:
 let g:bullets_set_mappings = 0 " disable adding default key mappings, default = 1
 
 " default = []
+" N.B. You can set these mappings as-is without using this g:bullets_custom_mappings option but it
+" will apply in this case for all file types while when using g:bullets_custom_mappings it would
+" take into account file types filter set in g:bullets_enabled_file_types, and also
+" g:bullets_enable_in_empty_buffers option.
 let g:bullets_custom_mappings = [
   \ ['imap', '<cr>', '<Plug>(bullets-newline)'],
   \ ['inoremap', '<C-cr>', '<cr>'],

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -34,6 +34,18 @@ if !exists('g:bullets_mapping_leader')
   let g:bullets_mapping_leader = ''
 end
 
+" Extra key mappings in addition to default ones.
+" If you don’t need default mappings set 'g:bullets_set_mappings' to '0'.
+" N.B. 'g:bullets_mapping_leader' has no effect on these mappings.
+"
+" Example:
+"   let g:bullets_custom_mappings = [
+"     \ ['imap', '<cr>', '<Plug>(bullets-newline)'],
+"     \ ]
+if !exists('g:bullets_custom_mappings')
+  let g:bullets_custom_mappings = []
+endif
+
 if !exists('g:bullets_delete_last_bullet_if_empty')
   let g:bullets_delete_last_bullet_if_empty = 1
 end
@@ -986,14 +998,14 @@ inoremap <silent> <Plug>(bullets-promote) <C-o>:BulletPromote<cr>
 nnoremap <silent> <Plug>(bullets-promote) :BulletPromote<cr>
 vnoremap <silent> <Plug>(bullets-promote) :BulletPromoteVisual<cr>
 
-fun! s:add_local_mapping(mapping_type, mapping, action)
+fun! s:add_local_mapping(with_leader, mapping_type, mapping, action)
   let l:file_types = join(g:bullets_enabled_file_types, ',')
   execute 'autocmd FileType ' .
         \ l:file_types .
         \ ' ' .
         \ a:mapping_type .
         \ ' <silent> <buffer> ' .
-        \ g:bullets_mapping_leader .
+        \ (a:with_leader ? g:bullets_mapping_leader : '') .
         \ a:mapping .
         \ ' ' .
         \ a:action
@@ -1002,7 +1014,7 @@ fun! s:add_local_mapping(mapping_type, mapping, action)
     execute 'autocmd BufEnter * if bufname("") == "" | ' .
           \ a:mapping_type .
           \ ' <silent> <buffer> ' .
-          \ g:bullets_mapping_leader .
+          \ (a:with_leader ? g:bullets_mapping_leader : '') .
           \ a:mapping .
           \ ' ' .
           \ a:action .
@@ -1015,26 +1027,30 @@ augroup TextBulletsMappings
 
   if g:bullets_set_mappings
     " Automatic bullets
-    call s:add_local_mapping('imap', '<cr>', '<Plug>(bullets-newline)')
-    call s:add_local_mapping('inoremap', '<C-cr>', '<cr>')
+    call s:add_local_mapping(1, 'imap', '<cr>', '<Plug>(bullets-newline)')
+    call s:add_local_mapping(1, 'inoremap', '<C-cr>', '<cr>')
 
-    call s:add_local_mapping('nmap', 'o', '<Plug>(bullets-newline)')
+    call s:add_local_mapping(1, 'nmap', 'o', '<Plug>(bullets-newline)')
 
     " Renumber bullet list
-    call s:add_local_mapping('vmap', 'gN', '<Plug>(bullets-renumber)')
-    call s:add_local_mapping('nmap', 'gN', '<Plug>(bullets-renumber)')
+    call s:add_local_mapping(1, 'vmap', 'gN', '<Plug>(bullets-renumber)')
+    call s:add_local_mapping(1, 'nmap', 'gN', '<Plug>(bullets-renumber)')
 
     " Toggle checkbox
-    call s:add_local_mapping('nmap', '<leader>x', '<Plug>(bullets-toggle-checkbox)')
+    call s:add_local_mapping(1, 'nmap', '<leader>x', '<Plug>(bullets-toggle-checkbox)')
 
     " Promote and Demote outline level
-    call s:add_local_mapping('imap', '<C-t>', '<Plug>(bullets-demote)')
-    call s:add_local_mapping('nmap', '>>', '<Plug>(bullets-demote)')
-    call s:add_local_mapping('vmap', '>', '<Plug>(bullets-demote)')
-    call s:add_local_mapping('imap', '<C-d>', '<Plug>(bullets-promote)')
-    call s:add_local_mapping('nmap', '<<', '<Plug>(bullets-promote)')
-    call s:add_local_mapping('vmap', '<', '<Plug>(bullets-promote)')
+    call s:add_local_mapping(1, 'imap', '<C-t>', '<Plug>(bullets-demote)')
+    call s:add_local_mapping(1, 'nmap', '>>', '<Plug>(bullets-demote)')
+    call s:add_local_mapping(1, 'vmap', '>', '<Plug>(bullets-demote)')
+    call s:add_local_mapping(1, 'imap', '<C-d>', '<Plug>(bullets-promote)')
+    call s:add_local_mapping(1, 'nmap', '<<', '<Plug>(bullets-promote)')
+    call s:add_local_mapping(1, 'vmap', '<', '<Plug>(bullets-promote)')
   end
+
+  for s:custom_key_mapping in g:bullets_custom_mappings
+    call call('<SID>add_local_mapping', [0] + s:custom_key_mapping)
+  endfor
 augroup END
 " --------------------------------------------------------- }}}
 

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -100,7 +100,7 @@ endif
 
 " Parse Bullet Type -------------------------------------------  {{{
 fun! s:parse_bullet(line_num, line_text)
-        
+
   let l:bullet = s:match_bullet_list_item(a:line_text)
   " Must be a bullet to be a checkbox
   let l:check = !empty(l:bullet) ? s:match_checkbox_bullet_item(a:line_text) : {}
@@ -966,6 +966,26 @@ command! -range=% BulletPromoteVisual call <SID>visual_change_bullet_level(1)
 " --------------------------------------------------------- }}}
 
 " Keyboard mappings --------------------------------------- {{{
+
+" Automatic bullets
+inoremap <silent> <Plug>(bullets-newline) <C-]><C-R>=<SID>insert_new_bullet()<cr>
+nnoremap <silent> <Plug>(bullets-newline) :call <SID>insert_new_bullet()<cr>
+
+" Renumber bullet list
+vnoremap <silent> <Plug>(bullets-renumber) :RenumberSelection<cr>
+nnoremap <silent> <Plug>(bullets-renumber) :RenumberList<cr>
+
+" Toggle checkbox
+nnoremap <silent> <Plug>(bullets-toggle-checkbox) :ToggleCheckbox<cr>
+
+" Promote and Demote outline level
+inoremap <silent> <Plug>(bullets-demote) <C-o>:BulletDemote<cr>
+nnoremap <silent> <Plug>(bullets-demote) :BulletDemote<cr>
+vnoremap <silent> <Plug>(bullets-demote) :BulletDemoteVisual<cr>
+inoremap <silent> <Plug>(bullets-promote) <C-o>:BulletPromote<cr>
+nnoremap <silent> <Plug>(bullets-promote) :BulletPromote<cr>
+vnoremap <silent> <Plug>(bullets-promote) :BulletPromoteVisual<cr>
+
 fun! s:add_local_mapping(mapping_type, mapping, action)
   let l:file_types = join(g:bullets_enabled_file_types, ',')
   execute 'autocmd FileType ' .
@@ -994,26 +1014,26 @@ augroup TextBulletsMappings
   autocmd!
 
   if g:bullets_set_mappings
-    " automatic bullets
-    call s:add_local_mapping('inoremap', '<cr>', '<C-]><C-R>=<SID>insert_new_bullet()<cr>')
+    " Automatic bullets
+    call s:add_local_mapping('imap', '<cr>', '<Plug>(bullets-newline)')
     call s:add_local_mapping('inoremap', '<C-cr>', '<cr>')
 
-    call s:add_local_mapping('nnoremap', 'o', ':call <SID>insert_new_bullet()<cr>')
+    call s:add_local_mapping('nmap', 'o', '<Plug>(bullets-newline)')
 
     " Renumber bullet list
-    call s:add_local_mapping('vnoremap', 'gN', ':RenumberSelection<cr>')
-    call s:add_local_mapping('nnoremap', 'gN', ':RenumberList<cr>')
+    call s:add_local_mapping('vmap', 'gN', '<Plug>(bullets-renumber)')
+    call s:add_local_mapping('nmap', 'gN', '<Plug>(bullets-renumber)')
 
     " Toggle checkbox
-    call s:add_local_mapping('nnoremap', '<leader>x', ':ToggleCheckbox<cr>')
+    call s:add_local_mapping('nmap', '<leader>x', '<Plug>(bullets-toggle-checkbox)')
 
     " Promote and Demote outline level
-    call s:add_local_mapping('inoremap', '<C-t>', '<C-o>:BulletDemote<cr>')
-    call s:add_local_mapping('nnoremap', '>>', ':BulletDemote<cr>')
-    call s:add_local_mapping('inoremap', '<C-d>', '<C-o>:BulletPromote<cr>')
-    call s:add_local_mapping('nnoremap', '<<', ':BulletPromote<cr>')
-    call s:add_local_mapping('vnoremap', '>', ':BulletDemoteVisual<cr>')
-    call s:add_local_mapping('vnoremap', '<', ':BulletPromoteVisual<cr>')
+    call s:add_local_mapping('imap', '<C-t>', '<Plug>(bullets-demote)')
+    call s:add_local_mapping('nmap', '>>', '<Plug>(bullets-demote)')
+    call s:add_local_mapping('vmap', '>', '<Plug>(bullets-demote)')
+    call s:add_local_mapping('imap', '<C-d>', '<Plug>(bullets-promote)')
+    call s:add_local_mapping('nmap', '<<', '<Plug>(bullets-promote)')
+    call s:add_local_mapping('vmap', '<', '<Plug>(bullets-promote)')
   end
 augroup END
 " --------------------------------------------------------- }}}


### PR DESCRIPTION
Closes https://github.com/dkarter/bullets.vim/issues/127

This change introduces two things:

1. `<Plug>...` mappings for easier reuse
2. `g:bullets_custom_mappings` option where you can customize all the key mappings

I added a usage example for new `g:bullets_custom_mappings` option to the README.