### PR TITLE
adding support for '+ [ ]: ' checkboxes

### DIFF
--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -243,9 +243,9 @@ fun! s:match_checkbox_bullet_item(input_text)
   " match any symbols listed in g:bullets_checkbox_markers as well as the
   " default ' ', 'x', and 'X'
   let l:checkbox_bullet_regex =
-        \ '\v(^(\s*)([-\*] \[(['
+        \ '\v(^(\s*)([+-\*] \[(['
         \ . g:bullets_checkbox_markers
-        \ . ' xX])?\])(\s+))(.*)'
+        \ . ' xX])?\])(:?)(\s+))(.*)'
   let l:matches = matchlist(a:input_text, l:checkbox_bullet_regex)
 
   if empty(l:matches)
@@ -256,8 +256,9 @@ fun! s:match_checkbox_bullet_item(input_text)
   let l:leading_space     = l:matches[2]
   let l:bullet            = l:matches[3]
   let l:checkbox_marker   = l:matches[4]
-  let l:trailing_space    = l:matches[5]
-  let l:text_after_bullet = l:matches[6]
+  let l:trailing_char     = l:matches[5]
+  let l:trailing_space    = l:matches[6]
+  let l:text_after_bullet = l:matches[7]
 
   return {
         \ 'bullet_type':       'chk',
@@ -265,7 +266,7 @@ fun! s:match_checkbox_bullet_item(input_text)
         \ 'leading_space':     l:leading_space,
         \ 'bullet':            l:bullet,
         \ 'checkbox_marker':   l:checkbox_marker,
-        \ 'closure':           '',
+        \ 'closure':           l:trailing_char,
         \ 'trailing_space':    l:trailing_space,
         \ 'text_after_bullet': l:text_after_bullet
         \ }
@@ -544,7 +545,7 @@ endfun
 " Checkboxes ---------------------------------------------- {{{
 fun! s:find_checkbox_position(lnum)
   let l:line_text = getline(a:lnum)
-  return matchend(l:line_text, '\v\s*(\*|-) \[')
+  return matchend(l:line_text, '\v\s*(\*|-|\+) \[')
 endfun
 
 fun! s:select_checkbox(inner)


### PR DESCRIPTION
the extra character of `:` is useful when grepping through files for specific todo tasks, especially when using https://github.com/folke/todo-comments.nvim (with vim regex - https://github.com/folke/todo-comments.nvim/pull/171).

the `+` was also added in addition to `-` and `*` as chars for standard list in markdown.