### PR TITLE
Do not change selection to update lists

### DIFF
--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -532,18 +532,11 @@ fun! s:insert_new_bullet()
       " insert next bullet
       call append(l:curr_line_num, l:next_bullet_list)
 
-
-      " go to next line after the new bullet
-      let l:col = strlen(getline(l:next_line_num)) + 1
-      call setpos('.', [0, l:next_line_num, l:col])
-
       " indent if previous line ended in a colon
       if l:indent_next
         " demote the new bullet
-        call s:change_bullet_level_and_renumber(-1)
+        call s:change_line_bullet_level(-1, l:next_line_num)
         " reset cursor position after indenting
-        let l:col = strlen(getline(l:next_line_num)) + 1
-        call setpos('.', [0, l:next_line_num, l:col])
       elseif g:bullets_renumber_on_change
         call s:renumber_whole_list()
       endif

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -321,6 +321,10 @@ fun! s:get_selection()
 endfun
 
 fun! s:set_selection(sel)
+  if a:se1 == s:get_selection()
+      return
+  endif
+
   let l:start_col = strlen(getline(a:sel.start_line)) - a:sel.start_offset
   let l:end_col = strlen(getline(a:sel.end_line)) - a:sel.end_offset
 

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -870,7 +870,7 @@ fun! s:change_bullet_level(direction, lnum)
   endif
 
   let l:curr_indent = indent(a:lnum)
-  let l:curr_bullet= s:closest_bullet_types(a:lnum, l:curr_indent)
+  let l:curr_bullet = s:closest_bullet_types(a:lnum, l:curr_indent)
   let l:curr_bullet = s:resolve_bullet_type(l:curr_bullet)
 
   let l:curr_line = l:curr_bullet.starting_at_line_num
@@ -962,7 +962,7 @@ endfun
 
 fun! s:change_bullet_level_and_renumber(direction)
   " Calls change_bullet_level and then renumber_whole_list if required
-  call s:change_bullet_level(a:direction, line(','))
+  call s:change_bullet_level(a:direction, line('.'))
   if g:bullets_renumber_on_change
       call s:renumber_whole_list()
   endif

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -1078,7 +1078,6 @@ fun! s:get_visual_selection_lines()
     call add(l:lines_with_index, {'text': l:line, 'nr': l:index})
     let l:index += 1
   endfor
-  echom l:lines_with_index
   return l:lines_with_index
 endfun
 

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -532,11 +532,18 @@ fun! s:insert_new_bullet()
       " insert next bullet
       call append(l:curr_line_num, l:next_bullet_list)
 
+
+      " go to next line after the new bullet
+      let l:col = strlen(getline(l:next_line_num)) + 1
+      call setpos('.', [0, l:next_line_num, l:col])
+
       " indent if previous line ended in a colon
       if l:indent_next
         " demote the new bullet
         call s:change_line_bullet_level(-1, l:next_line_num)
         " reset cursor position after indenting
+        let l:col = strlen(getline(l:next_line_num)) + 1
+        call setpos('.', [0, l:next_line_num, l:col])
       elseif g:bullets_renumber_on_change
         call s:renumber_whole_list()
       endif

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -305,14 +305,14 @@ fun! s:get_selection()
   if l:mode ==# 'v' || l:mode ==# 'V' || l:mode ==# "\<C-v>"
     let [l:start_line, l:start_col] = getpos("'<")[1:2]
     let l:sel.start_line = l:start_line
-    let l:sel.start_offset = strlen(getline(sel.start_line)) - l:start_col + 1
+    let l:sel.start_offset = strlen(getline(sel.start_line)) - l:start_col
     let [l:end_line, l:end_col] = getpos("'>")[1:2]
     let l:sel.end_line = l:end_line
-    let l:sel.end_offset = strlen(getline(sel.end_line)) - l:end_col[2] + 1
+    let l:sel.end_offset = strlen(getline(sel.end_line)) - l:end_col
     let l:sel.visual_mode = l:mode
   else
     let l:sel.start_line = line('.')
-    let l:sel.start_offset = strlen(getline(sel.start_line)) - col('.') + 1
+    let l:sel.start_offset = strlen(getline(sel.start_line)) - col('.')
     let l:sel.end_line = l:sel.start_line
     let l:sel.end_offset = l:sel.start_offset
     let l:sel.visual_mode = ''
@@ -321,17 +321,11 @@ fun! s:get_selection()
 endfun
 
 fun! s:set_selection(sel)
-  if a:sel == s:get_selection()
-    return
-  endif
+  let l:start_col = strlen(getline(a:sel.start_line)) - a:sel.start_offset
+  let l:end_col = strlen(getline(a:sel.end_line)) - a:sel.end_offset
 
-  let l:start_col = strlen(getline(a:sel.start_line)) - a:sel.start_offset + 1
-  let l:end_col = strlen(getline(a:sel.end_line)) - a:sel.end_offset + 1
-
-  if a:sel.start_line == a:sel.end_line && l:start_col == l:end_col
-    call cursor(a:sel.start_line, l:start_col)
-  else
-    call cursor(a:sel.start_line, l:start_col)
+  call cursor(a:sel.start_line, l:start_col)
+  if a:sel.start_line != a:sel.end_line || l:start_col != l:end_col
     if a:sel.visual_mode == "\<C-v>"
       execute "normal! \<C-v>"
     elseif a:sel.visual_mode == 'V' || a:sel.visual_mode == 'v'
@@ -795,7 +789,6 @@ endfun
 fun! s:renumber_selection()
     let l:sel = s:get_selection()
     call s:renumber_lines(l:sel.start_line, l:sel.end_line)
-    call s:set_selection(l:sel)
 endfun
 
 fun! s:renumber_lines(start, end)
@@ -880,13 +873,11 @@ endfun
 
 " Renumbers the whole list containing the cursor.
 fun! s:renumber_whole_list()
-  let l:sel = s:get_selection()
   let l:first_line = s:first_bullet_line(line('.'))
   let l:last_line = s:last_bullet_line(line('.'))
   if l:first_line > 0 && l:last_line > 0
     call s:renumber_lines(l:first_line, l:last_line)
   endif
-  call s:set_selection(l:sel)
 endfun
 
 command! -range=% RenumberSelection call <SID>renumber_selection()

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -321,7 +321,7 @@ fun! s:get_selection()
 endfun
 
 fun! s:set_selection(sel)
-  if a:se1 == s:get_selection()
+  if a:sel == s:get_selection()
       return
   endif
 

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -895,7 +895,7 @@ command! RenumberList call <SID>renumber_whole_list()
 " --------------------------------------------------------- }}}
 
 " Changing outline level ---------------------------------- {{{
-fun! s:change_bullet_level(direction, lnum)
+fun! s:change_line_bullet_level(direction, lnum)
   let l:curr_line = s:parse_bullet(a:lnum, getline(a:lnum))
 
   if a:direction == 1
@@ -1007,7 +1007,7 @@ fun! s:change_bullet_level(direction)
   " Changes the bullet level for each of the selected lines
   let l:sel = s:get_selection()
   for l:lnum in range(l:sel.start_line, l:sel.end_line)
-    call s:change_bullet_level(a:direction, l:lnum)
+    call s:change_line_bullet_level(a:direction, l:lnum)
   endfor
 
   if g:bullets_renumber_on_change


### PR DESCRIPTION
In this PR I have modified several functions to eliminate the need for modifying the current selection or cursor position.

This results in:
1. Much smaller and cleaner code
2. Reduced chance that selection is accidentally changed when renumbering etc
3. Improved performance in some cases

I have also added logic to explicitly save the cursor / selection position and have it restored after the change.